### PR TITLE
[FE 윤동현] - Taskify | Task 생성 및 세부 기능 구현 / Task 이동 및 세부 기능 구현

### DIFF
--- a/components/cardForm.js
+++ b/components/cardForm.js
@@ -77,8 +77,8 @@ export default function CardForm() {
     return (
         `
             <form class="card_form card surface-default shadow-normal rounded-100">
-                <input name="title" class="text-strong display-bold14" type="text" placeholder="제목을 입력하세요"/>
-                <input name="content" class="text-default display-medium14" type="text" placeholder="내용을 입력하세요"/>
+                <input name="title" class="text-strong display-bold14" type="text" placeholder="제목을 입력하세요" maxlength="500" />
+                <input name="content" class="text-default display-medium14" type="text" placeholder="내용을 입력하세요" maxlength="500" />
                 <span>
                     <button class="rounded-100 surface-alt text-default display-bold14" type="button">취소</button>
                     <button class="rounded-100 surface-brand text-white-default display-bold14 disabled" disabled type="submit">제출</button>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <header>
         <h1 class="text-strong display-bold24">TASKIFY</h1>
         <button>
-            <img width="24" height="24" src="/public/icon/clock.svg"/>
+            <img draggable="false" width="24" height="24" src="/public/icon/clock.svg" />
         </button>
     </header>
     <main>
@@ -27,10 +27,10 @@
                     <span class="column_task_counter text-weak display-medium12">0</span>
                     <span class="column_button_container">
                         <button>
-                            <img width="24" height="24" src="/public/icon/plus.svg" />
+                            <img draggable="false" width="24" height="24" src="/public/icon/plus.svg" />
                         </button>
                         <button>
-                            <img width="24" height="24" src="/public/icon/closed.svg" />
+                            <img draggable="false" width="24" height="24" src="/public/icon/closed.svg" />
                         </button>
                     </span>
                 </h3>
@@ -45,10 +45,10 @@
                     <span class="column_task_counter text-weak display-medium12">0</span>
                     <span class="column_button_container">
                         <button>
-                            <img width="24" height="24" src="/public/icon/plus.svg" />
+                            <img draggable="false" width="24" height="24" src="/public/icon/plus.svg" />
                         </button>
                         <button>
-                            <img width="24" height="24" src="/public/icon/closed.svg" />
+                            <img draggable="false" width="24" height="24" src="/public/icon/closed.svg" />
                         </button>
                     </span>
                 </h3>
@@ -63,15 +63,15 @@
                     <span class="column_task_counter text-weak display-medium12">0</span>
                     <span class="column_button_container">
                         <button>
-                            <img width="24" height="24" src="/public/icon/plus.svg" />
+                            <img draggable="false" width="24" height="24" src="/public/icon/plus.svg" />
                         </button>
                         <button>
-                            <img width="24" height="24" src="/public/icon/closed.svg" />
+                            <img draggable="false" width="24" height="24" src="/public/icon/closed.svg" />
                         </button>
                     </span>
                 </h3>
                 <div class="card_add"></div>
-                <ol class="card_list" >
+                <ol class="card_list">
 
                 </ol>
             </li>

--- a/public/main.css
+++ b/public/main.css
@@ -41,7 +41,24 @@ main {
 
 .column_button_container {
     margin-left: auto;
+
+    >button {
+        &:first-of-type {
+            &:hover {
+                filter: invert(34%) sepia(33%) saturate(6685%) hue-rotate(200deg) brightness(102%) contrast(106%);
+            }
+
+        }
+
+        &:last-of-type {
+            &:hover {
+                filter: invert(35%) sepia(50%) saturate(6582%) hue-rotate(343deg) brightness(110%) contrast(99%);
+            }
+        }
+    }
 }
+
+
 
 .card {
     display: flex;

--- a/public/main.css
+++ b/public/main.css
@@ -15,12 +15,13 @@ main {
     width: 320px;
     min-width: 320px;
     margin-right: 32px;
+
     &:last-of-type {
         margin: 0;
     }
 }
 
-.column > ol {
+.column>ol {
     list-style-type: none;
 }
 
@@ -28,6 +29,7 @@ main {
     display: flex;
     align-items: center;
     padding: 0 16px;
+
     span {
         display: flex;
 
@@ -69,6 +71,8 @@ main {
 
 .card_text_container {
     flex-grow: 1;
+    word-break: break-all;
+
     h4 {
         margin-bottom: 8px;
     }

--- a/script/column.js
+++ b/script/column.js
@@ -5,6 +5,14 @@ import { createTask } from './task.js';
 
 export function createTaskForm(columnIdx) {
     const cardFormArea = document.getElementsByClassName("card_add")[columnIdx];
+    
+    // 이미 Form이 존재하는 경우, + 버튼으로 존재하는 Form을 닫기
+    const isCardFormExists = cardFormArea.children.length !== 0;
+    if(isCardFormExists) {
+        cardFormArea.removeChild(cardFormArea.children[0])
+        return;
+    }
+
     cardFormArea.innerHTML = CardForm();
     const forms = document.getElementsByClassName('card_form');
     

--- a/script/index.js
+++ b/script/index.js
@@ -1,40 +1,149 @@
 import { createTaskForm, renderTasks } from "./column.js";
-
-const buttonContainers = document.getElementsByClassName('column_button_container');
+import { createTask, taskHTML } from "./task.js";
 
 let dragged = null;
+let draggedElement = null;
+export let columns = [];
 
 export function handleDrag(e, task) {
+    console.log(task);
     dragged = task;
+    draggedElement = e.target;
+}
+
+function handleDropContainer(e) {
+    if(e.target.tagName === 'UL') {
+        draggedElement.style.opacity = 1;
+        dragged = null;
+        draggedElement = null;
+        return;
+    }
 }
 
 function handleDrop(e) {
-    const columnIdx = e.target.getAttribute('index');
+    e.stopPropagation();
+    const columnIdx = Number(e.currentTarget.getAttribute("index"));
     const currentIdx = dragged.column;
 
-    if(columnIdx === currentIdx) return;
+    if (columnIdx === currentIdx) {
+        draggedElement.style.opacity = 1;
+        dragged = null;
+        draggedElement = null;
+        return;
+    }
 
-    columns[currentIdx] = columns[currentIdx].filter(el => el!=dragged)
-    columns[columnIdx].push({...dragged, column : columnIdx})
+    columns[currentIdx] = columns[currentIdx].filter((el) => el != dragged);
+    columns[columnIdx].push({ ...dragged, column: columnIdx });
+    dragged = null;
+    draggedElement = null;
 
     renderTasks(columnIdx);
     renderTasks(currentIdx);
 }
 
-const columnElements = document.getElementsByClassName('column');
+function createDummyTask(task) {
+    const { title, content, created, column } = task;
 
-for(let column of columnElements) {
-    column.addEventListener('dragover', (e)=>{e.preventDefault();})
-    column.addEventListener('drop', handleDrop)
+    // 새 카드 컴포넌트 생성
+    const newCard = document.createElement("li");
+    newCard.setAttribute(
+        "class",
+        "card surface-default shadow-normal rounded-100"
+    );
+    newCard.setAttribute("id", "dummy");
+    newCard.innerHTML = taskHTML({ title, content });
+    newCard.style.opacity = 0.3;
+
+    return newCard;
 }
 
-for(let i=0; i<buttonContainers.length; i++) {
-    const buttons = buttonContainers[i].getElementsByTagName('button');
-    const [addButton, deleteButton] = buttons;
-    addButton.addEventListener('click', ()=>createTaskForm(i));
+
+// column에 drag 대상이 들어올 경우
+function handleDragEnter(e) {
+    e.stopPropagation();
+    // 같은 column 내부에서는 이벤트 진행 방지
+    if (e.currentTarget.contains(e.relatedTarget)) return;
+
+    const columnIdx = Number(e.currentTarget.getAttribute("index"));
+    if (columnIdx === undefined || columnIdx === null) return;
+
+    // 초기 드래그 대상 투명화
+    if (dragged.column === columnIdx) {
+        draggedElement.style.opacity = 0.3;
+        return;
+    }
+
+    const columnListElement = e.currentTarget.getElementsByTagName("ol")[0];
+
+    // 잔상 중복 생성 방지
+    const dummy = columnListElement.querySelector("#dummy");
+    if (dummy) return;
+    const dummyCard = createDummyTask(dragged);
+
+    columnListElement.appendChild(dummyCard);
 }
 
-export let columns = [];
-for(let i=0; i<3; i++) {
-    columns.push([]);
+// column drag 대상이 나갈 경우
+function handleDragLeave(e) {
+    e.stopPropagation();
+    // 같은 column 내부에서는 이벤트 진행 방지
+    if (e.currentTarget.contains(e.relatedTarget)) return;
+
+    const columnIdx = Number(e.currentTarget.getAttribute("index"));
+    if (columnIdx === undefined || columnIdx === null) return;
+
+    // 초기 드래그 대상 투명화
+    if (dragged.column === columnIdx) {
+        draggedElement.style.opacity = 0;
+        return;
+    }
+
+    const columnListElement = e.currentTarget.getElementsByTagName("ol")[0];
+
+    // Enter시 생성한 dummy 제거
+    const dummy = columnListElement.querySelector("#dummy");
+    if (dummy) {
+        columnListElement.removeChild(dummy);
+    }
 }
+
+// 초기 이벤트 등록 및 mock 데이터 생성
+function init() {
+    const columnElements = document.getElementsByClassName("column");
+    const columnContainer = document.getElementById("column_container");
+    columnContainer.addEventListener('dragover', (e)=>{e.preventDefault()})
+    columnContainer.addEventListener('drop', handleDropContainer);
+    
+    for (let column of columnElements) {
+        // drop event를 사용하기 위해서는 dragover에서 e.preventDefault가 선언되어야 함.
+        column.addEventListener("dragover", (e) => {
+            e.preventDefault();
+        });
+        column.addEventListener("drop", handleDrop);
+        column.addEventListener("dragenter", handleDragEnter);
+        column.addEventListener("dragleave", handleDragLeave);
+    }
+
+    const buttonContainers = document.getElementsByClassName(
+        "column_button_container"
+    );
+    for (let i = 0; i < buttonContainers.length; i++) {
+        const buttons = buttonContainers[i].getElementsByTagName("button");
+        const [addButton, deleteButton] = buttons;
+        addButton.addEventListener("click", () => createTaskForm(i));
+    }
+
+    for (let i = 0; i < 3; i++) {
+        columns.push([]);
+    }
+
+    columns[0].push({
+        title: "제목1",
+        content: "내용1",
+        column: 0,
+        created: "test",
+    });
+    renderTasks(0);
+}
+
+init();

--- a/script/task.js
+++ b/script/task.js
@@ -1,4 +1,4 @@
-import CardForm, { onCancelEdit, onEdit, onSubmit } from "../components/cardForm.js";
+import CardForm, { onCancelEdit, onEdit } from "../components/cardForm.js";
 import Modal from "../components/modal.js";
 import { renderTasks } from "./column.js";
 import { columns, handleDrag } from "./index.js";
@@ -6,22 +6,22 @@ import { createModalChildren } from "./modal.js";
 
 export function createDeleteModal(task) {
     const body = document.getElementsByTagName("body")[0];
-    const modalElement = createModalChildren('선택한 카드를 삭제할까요?', ()=>deleteTask(task))
+    const modalElement = createModalChildren("선택한 카드를 삭제할까요?", () =>
+        deleteTask(task)
+    );
     const modal = Modal(modalElement);
     body.appendChild(modal);
 }
 
-
-
 export function createTask(task) {
-    const {title, content, created, column} = task;
-    
+    const { title, content, created, column } = task;
+
     // 새 카드 컴포넌트 생성
-    const newCard = document.createElement('li')
-    newCard.setAttribute('class', 'card surface-default shadow-normal rounded-100')
-    newCard.setAttribute('draggable', 'true')
-    newCard.innerHTML = taskHTML({title, content});
-    newCard.addEventListener("dragstart", (e)=>handleDrag(e, task));
+    const newCard = document.createElement("li");
+    newCard.setAttribute("class", "card surface-default shadow-normal rounded-100");
+    newCard.setAttribute("draggable", "true");
+    newCard.innerHTML = taskHTML({ title, content });
+    newCard.addEventListener("dragstart", (e) => handleDrag(e, task));
     // 이벤트 등록
     taskEventHandler(newCard, task);
 
@@ -29,45 +29,47 @@ export function createTask(task) {
 }
 
 export function deleteTask(task) {
-    const {title, content, created, column} = task;
-    columns[column] = columns[column].filter(el => el != task);
+    const { title, content, created, column } = task;
+    columns[column] = columns[column].filter((el) => el != task);
     renderTasks(column);
 }
 
 export function editTask(cardElement, task) {
-    const {title, content, created, column} = task;
+    const { title, content, created, column } = task;
     cardElement.innerHTML = CardForm();
-    const inputs = cardElement.getElementsByTagName('input');
-    const [titleInput, contentInput] = inputs
+    const inputs = cardElement.getElementsByTagName("input");
+    const [titleInput, contentInput] = inputs;
     titleInput.value = title;
     contentInput.value = content;
-    const form = cardElement.getElementsByTagName('form')[0];
-    form.addEventListener('submit', (e)=>{onEdit(e, task)})
-    form.getElementsByTagName('button')[0].addEventListener('click', ()=>onCancelEdit(task, cardElement))
+    const form = cardElement.getElementsByTagName("form")[0];
+    form.addEventListener("submit", (e) => {
+        onEdit(e, task);
+    });
+    form.getElementsByTagName("button")[0].addEventListener("click", () =>
+        onCancelEdit(task, cardElement)
+    );
 }
 
-export function taskHTML({title, content}) {
-    return (
-    `
+export function taskHTML({ title, content }) {
+    return `
         <div class="card_text_container">
             <h4 class="text-strong display-bold14">${title}</h4>
             <p class="text-weak display-medium14">${content}</p>
         </div>
         <div class="card_button_container">
             <button>
-                <img width="24" height="24" src="/public/icon/closed.svg"/>
+                <img draggable="false" width="24" height="24" src="/public/icon/closed.svg"/>
             </button>
             <button>
-                <img width="24" height="24" src="/public/icon/edit.svg"/>
+                <img draggable="false" width="24" height="24" src="/public/icon/edit.svg"/>
             </button>
         </div>
-    `
-    )
+    `;
 }
 
 export function taskEventHandler(cardElement, task) {
-    const buttons = cardElement.getElementsByTagName('button');
+    const buttons = cardElement.getElementsByTagName("button");
     const [deleteButton, editButton] = buttons;
-    deleteButton.addEventListener('click', ()=>createDeleteModal(task));
-    editButton.addEventListener('click', ()=>editTask(cardElement, task));
+    deleteButton.addEventListener("click", () => createDeleteModal(task));
+    editButton.addEventListener("click", () => editTask(cardElement, task));
 }


### PR DESCRIPTION
# Task 생성
## 주요 작업
- [x]  1. task 생성 - 리스트에 새 task 추가 및 form 제작
    - [x]  hover 스타일 변경
    - [x]  컨텐츠 유무에 의한 비활성화
    - [x]  글자 수 제한 (500)
    - [x]  + 버튼으로 task form toggle 하기
  
## 학습 키워드
CSS, JavaScript 이벤트

## 고민과 해결과정
1. element.children과 element.firstChild의 차이점
   - +버튼으로 task를 생성하기 위한 Form을 만든다. 만일 Form이 이미 존재한다면 +버튼을 눌렀을 때, Form을 지운다.
   - 해당 문제를 해결하기 위해 "card_add" class 명을 가진 div가 가진 child로 해당 문제를 해결하려 하였다.
   - 기존에 작성해둔 코드로는 "card_add" div에는 하나의 Form만 존재하기에 firstNode를 removeChild로 삭제하였으나 Form이 남아있는 문제를 확인할 수 있었다.
   - console로 firstChild와 childNodes를 확인한 결과 
   - <img width="784" alt="image" src="https://github.com/user-attachments/assets/b51334cb-0565-41a4-bc99-9a9d6292f698" />
   - 다음과 같이 NodeList에는 form 하나만 있는 것이 아닌 text 노드들이 존재하는 것을 확인할 수 있었다.
   - [firstChild](https://developer.mozilla.org/ko/docs/Web/API/Node/firstChild) 문서를 확인한 결과, 공백 같은 텍스트또한 노드로 인식이 된다는 것을 알 수 있었고 모든 Node를 탐지하는 것이 아닌 HTMLElement를 탐지하기 위해 element.children으로 Form을 찾을 수 있었다.
   ```
    const isCardFormExists = cardFormArea.children.length !== 0;
    if(isCardFormExists) {
        cardFormArea.removeChild(cardFormArea.children[0])
        return;
    }
   ```
   - 다음과 children이 존재하는 경우, 첫 번째 Element를 삭제함으로서 Form을 toggle할 수 있는 기능을 구현하였다.

2. svg 스타일링
   - Column의 +, x 버튼에 마우스를 hover하면 스타일이 변경되는 기능이 필요하였다. 
   - img태그로 src로 불러온 경우, 직접적인 스타일 조정이 불가능하여, 2가지 선택지가 존재하였다.
   - 1. 변경될 색상의 svg를 생성하여 src를 js로 동적으로 변경하는 것, 2. CSS filter를 사용하여 hover시 색상을 변경하는 것
   - 이번 프로젝트에서는 CSS에 조금 더 익숙해지고 자주 사용하지 않았던 filter를 사용해보고자 2번을 선택하였다.
   - [CSS filter Generator](https://codepen.io/sosuke/pen/Pjoqqp) 검색을 통해 원하는 색상으로 변화시킬 수 있는 filter 생성기가 존재하여 이를 사용하여 CSS를 적용시킬 수 있었다.

# Task 이동
## 주요 작업
Task 이동 및 Task 투명화를 통한 이동 가이드라인 제공

## 학습 키워드
drag event, event.targets

## 고민과 해결과정
### 1. drag & drop event 등록
- Task 컴포넌트에 dragstart 이벤트를 부여하여 드래그 중인 task와 element를 전역으로 관리하려함.
- index.js 파일에서 dragged를 전역으로 선언하고 task 파일에서 해당 값을 import하여 수정하려하자 수정할 수 없다는 경고가 발생하여 drag handler를 index.js에서 선언하여 전역 변수를 다룰 수 있도록 문제를 해결
- 전역 변수 (global state)를 어떻게 선언하고 관리할 지에 대해 추가 고민이 필요함.
- Task들을 관리하는 최상위 컴포넌트 (column)에 drop event를 부여하여 드래그 중인 task가 drop 시, 이를 감지할 수 있도록 구현
- drop event 등록 시, dragover에 대하여 preventDefault가 필요하다는 것을 학습 [drop event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/drop_event)
- drop event 발생 시, dragged에 저장된 task의 column과 event가 발생한 column의 index를 비교하여 columns에서 해당 task를 이동
```
    columns[currentIdx] = columns[currentIdx].filter((el) => el != dragged);
    columns[columnIdx].push({ ...dragged, column: columnIdx });
```
시작 column에서 dragged를 제외하고 dragged를 도착 column에 추가. 이때, task에 저장된 column을 도착 column으로 설정
### 2. drag시 잔상 생성
- Drag시, Drag된 Task가 목적지 column에 잔상이 생기는 기획안이 존재하여 이를 구현
- 잔상 Task를 생성하여 각 column의 Array에 이를 추가/삭제
#### 2.1 Task 삭제
- 출발 column이 아닌 다른 column에 drop하기 위해 Drag된 상태로 마우스를 움직이는 경우에 기존 column에서 removeChild로 삭제하니 drag 이벤트 대상이 삭제되며 이벤트가 취소되는 문제가 발생 
- 이를 해결하기 위해, 실제 Drag되는 Task를 삭제하는 것이 아닌 Opacity를 조절하여 화면에 보이지 않도록 설정
- Drag Enter & Leave 이벤트로 각 column의 리스트에 드래그 대상이 들어온 경우, 출발 column과 도착 column을 비교하여 스타일을 적용
- [x] Drag Leave : 출발과 도착 column이 동일한 경우, Task의 opacity를 0으로 설정 / 다른 경우, Enter시 생성한 잔상 task를 제거
- [x] Drag Enter : 출발과 도착 column이 동일한 경우, Opacity가 0을 0.3으로 설정 / 다른 경우, 도착 column에 잔상 task 생성

#### 2.2 이벤트 중복 발생
- Drag Leave 및 Enter가 column의 빈 공간에서 발생 시, 원활하게 동작하나 마우스가 Task 위에서 발생 시, 잔상 생성 제거가 무한 반복하는 문제 발생
- 같은 column 내부에서는 Drag Enter 및 Leave를 무시하기 위해 event.currentTarget과 event.relatedTarget의 관계를 비교
- [x] currentTarget : event 핸들러가 걸려있는 Element
- [x] relatedTarget : 포인터가 이동하는 대상 Element
- 2개 target의 관계로 같은 column 내부에서 Task위에서의 이벤트 탐지를 처리함
    
```
        // 같은 column 내부에서는 이벤트 진행 방지
    if (e.currentTarget.contains(e.relatedTarget)) return;
```
- 근본적인 해결책이 아니므로 event Bubbling에 대해 더 조사할 필요가 있음