### PR TITLE
[hamo-o] - Button, Badge, Chip 컴포넌트 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # fe-taskify
 
-볼드처리된 목록이 브랜치 단위
-
 ## Foundation
 
 - [x]  **디자인 토큰 주입하기**
@@ -10,10 +8,10 @@
 ## Components
 
 - [ ]  **Core** (Base가 되는 컴포넌트)
-- [ ]  **Buttons**
+- [x]  **Buttons**
 - [ ]  **FAB**
-- [ ]  **Badge**
-- [ ]  **Chip**
+- [x]  **Badge**
+- [x]  **Chip**
 - [ ]  **Card**
     - [ ]  글자수 제한
     - [ ]  글자수에 따른 반응형

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -18,6 +18,10 @@ const App = () => {
   const icon = Button({
     showIcon: true,
   });
+  const ghost = Button({
+    label: "Button",
+    type: "ghost",
+  });
 
   return (
     parser`
@@ -30,6 +34,7 @@ const App = () => {
             ${button}
             ${iconButton}
             ${icon}
+            ${ghost}
         </div>`
   );
 };

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,9 +1,9 @@
+import { Badge } from "../components/Badge/index.js";
 import { Button } from "../components/Button/index.js";
 import { parser } from "../lib/jsx-runtime/index.js";
 
 // eslint-disable-next-line
 const App = () => {
-  const container = "hihi";
   const button = Button({
     label: "Button",
     // eslint-disable-next-line
@@ -23,18 +23,18 @@ const App = () => {
     type: "ghost",
   });
 
+  const badge = Badge({ text: "1" });
+  const badge2 = Badge({ text: "10" });
+
   return (
     parser`
-        <div class=${container}>
-            <div>
-                <h1>HI!!!</h1>
-                <h2>My name is Hamm</h2>
-            </div>
-            <div>hello</div>
+        <div>
             ${button}
             ${iconButton}
             ${icon}
             ${ghost}
+            ${badge}
+            ${badge2}
         </div>`
   );
 };

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,5 +1,6 @@
 import { Badge } from "../components/Badge/index.js";
 import { Button } from "../components/Button/index.js";
+import { Chip } from "../components/Chip/index.js";
 import { parser } from "../lib/jsx-runtime/index.js";
 
 // eslint-disable-next-line
@@ -26,6 +27,8 @@ const App = () => {
   const badge = Badge({ text: "1" });
   const badge2 = Badge({ text: "10" });
 
+  const chip = Chip({ label: "Chip" });
+
   return (
     parser`
         <div>
@@ -35,6 +38,7 @@ const App = () => {
             ${ghost}
             ${badge}
             ${badge2}
+            ${chip}
         </div>`
   );
 };

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -1,4 +1,5 @@
 @import url("../components//Button/button.module.css");
+@import url("../components//Badge/badge.module.css");
 @import url("./reset.css");
 
 :root {

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -1,5 +1,6 @@
 @import url("../components//Button/button.module.css");
 @import url("../components//Badge/badge.module.css");
+@import url("../components/Chip/chip.module.css");
 @import url("./reset.css");
 
 :root {

--- a/src/app/index.css
+++ b/src/app/index.css
@@ -1,6 +1,7 @@
 @import url("../components//Button/button.module.css");
 @import url("../components//Badge/badge.module.css");
 @import url("../components/Chip/chip.module.css");
+@import url("../components/Text/text.module.css");
 @import url("./reset.css");
 
 :root {

--- a/src/app/reset.css
+++ b/src/app/reset.css
@@ -1,6 +1,14 @@
 * {
     box-sizing: border-box;
   }
+
+html,
+body {
+    width: 100vw;
+    height: 100vh;
+    top: 0;
+    left: 0;
+}
   
 html,
 body,

--- a/src/components/Badge/badge.module.css
+++ b/src/components/Badge/badge.module.css
@@ -1,0 +1,16 @@
+.badge-container {
+    min-width: 24px;
+    height: 24px;
+    padding: var(--gap-50);
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    border: 1px solid var(--border-default);
+    border-radius: var(--gap-100);
+
+    color: var(--text-weak);
+
+    text-align: center;
+}

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -1,0 +1,25 @@
+import { typos } from "../../constants/tokens/typos.js";
+import { parser } from "../../lib/jsx-runtime/index.js";
+
+/**
+ *
+ * @param {object} props - 뱃지 컴포넌트의 props
+ * @param {string} props.text - 뱃지에 표시할 텍스트
+ * @returns {VDOM}
+ */
+export const Badge = ({ text }) => {
+  /**
+   * @returns {string} - 포매팅된 텍스트
+   */
+  const formatText = () => {
+    if (Number(text) > 9) {
+      return `${text}+`;
+    }
+    return text;
+  };
+
+  return parser`
+    <span class="badge-container ${typos.display.medium[12]}">
+        ${formatText()}
+    </span>`;
+};

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -1,5 +1,6 @@
 import { typos } from "../../constants/tokens/typos.js";
 import { parser } from "../../lib/jsx-runtime/index.js";
+import { Text } from "../Text/index.js";
 
 /**
  *
@@ -19,7 +20,7 @@ export const Badge = ({ text }) => {
   };
 
   return parser`
-    <span class="badge-container ${typos.display.medium[12]}">
-        ${formatText()}
+    <span class="badge-container">
+        ${Text({ text: formatText(), typo: typos.display.medium[12] })}
     </span>`;
 };

--- a/src/components/Button/button.module.css
+++ b/src/components/Button/button.module.css
@@ -22,3 +22,7 @@
     background-color: transparent;
     color: var(--text-default);
 }
+
+.button-full {
+    width: 100%;
+}

--- a/src/components/Button/button.module.css
+++ b/src/components/Button/button.module.css
@@ -22,7 +22,3 @@
     background-color: transparent;
     color: var(--text-default);
 }
-
-.button-text {
-    padding: 0 var(--gap-50) 0 var(--gap-50);
-}

--- a/src/components/Button/button.module.css
+++ b/src/components/Button/button.module.css
@@ -1,4 +1,4 @@
-.button-container {
+.button-contained, .button-ghost {
     padding: var(--gap-100);
 
     display: flex;
@@ -10,15 +10,19 @@
     border-radius: var(--gap-100);
 }
 
-.button-container:hover {
+.button-contained:hover, .button-ghost:hover {
     opacity: 80%;
 }
 
-.button-container:disabled {
+.button-contained:disabled, .button-ghost:hover {
     opacity: 30%;
+}
+
+.button-ghost {
+    background-color: transparent;
+    color: var(--text-default);
 }
 
 .button-text {
     padding: 0 var(--gap-50) 0 var(--gap-50);
 }
-

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -23,8 +23,12 @@ export const Button = ({
   label,
   type = "contained",
   onClick,
-}) => parser`
-<button onClick=${onClick} class="button-container ${typos.selected.bold[16]}">
+}) => {
+  const buttonType = `button-${type}`;
+
+  return parser`
+<button onClick=${onClick} class="${buttonType} ${typos.selected.bold[16]}">
     ${showIcon && Icon({ name: "plus", size: "md", fillColor: colors.text.white.default })}
     ${label && Text(label)}
 </button>`;
+};

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,13 +1,7 @@
 import { Icon } from "../../constants/icons/index.js";
 import { colors, typos } from "../../constants/tokens/index.js";
 import { parser } from "../../lib/jsx-runtime/index.js";
-
-/**
- *
- * @param {string} label - 버튼에 표시할 라벨
- * @returns {VDOM} - 생성된 텍스트 가상돔
- */
-const Text = (label) => parser`<span class="button-text">${label}</span>`;
+import { Text } from "../Text/index.js";
 
 /**
  *
@@ -27,8 +21,8 @@ export const Button = ({
   const buttonType = `button-${type}`;
 
   return parser`
-<button onClick=${onClick} class="${buttonType} ${typos.selected.bold[16]}">
+<button onClick=${onClick} class="${buttonType}">
     ${showIcon && Icon({ name: "plus", size: "md", fillColor: colors.text.white.default })}
-    ${label && Text(label)}
+    ${label && Text({ text: label, typo: typos.selected.bold[16] })}
 </button>`;
 };

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -10,18 +10,27 @@ import { Text } from "../Text/index.js";
  * @param {"contained"|"ghost"} [props.type] - 버튼의 타입
  * @param {boolean} [props.showIcon] - 아이콘을 표시할지 여부
  * @param {Function} [props.onClick] - 클릭 이벤트 시 호출할 함수
+ * @param {boolean} [props.isFull] - 버튼의 너비를 꽉 채울지 여부
  * @returns {HTMLElement} - 생성된 버튼 가상돔
  */
 export const Button = ({
   showIcon = false,
   label,
   type = "contained",
+  isFull = false,
   onClick,
 }) => {
-  const buttonType = `button-${type}`;
+  /**
+   * @returns {string} - 버튼의 클래스명
+   */
+  const findClasses = () => {
+    const buttonType = `button-${type}`;
+    if (isFull) return `${buttonType} button-full`;
+    return buttonType;
+  };
 
   return parser`
-<button onClick=${onClick} class="${buttonType}">
+<button onClick=${onClick} class="${findClasses()}">
     ${showIcon && Icon({ name: "plus", size: "md", fillColor: colors.text.white.default })}
     ${label && Text({ text: label, typo: typos.selected.bold[16] })}
 </button>`;

--- a/src/components/Chip/chip.module.css
+++ b/src/components/Chip/chip.module.css
@@ -1,0 +1,12 @@
+.chip-container {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    height: 24px;
+    padding: 0 var(--gap-100) 0 var(--gap-100);
+
+    border: 1px solid var(--border-bold);
+    border-radius: var(--gap-100);
+    color: var(--text-bold);
+}

--- a/src/components/Chip/index.js
+++ b/src/components/Chip/index.js
@@ -1,0 +1,16 @@
+import { Icon } from "../../constants/icons/index.js";
+import { colors } from "../../constants/tokens/colors.js";
+import { typos } from "../../constants/tokens/typos.js";
+import { parser } from "../../lib/jsx-runtime/index.js";
+
+/**
+ *
+ * @param {object} props - 칩 컴포넌트의 props
+ * @param {string} props.label - 칩에 표시할 라벨
+ * @returns {VDOM}
+ */
+export const Chip = ({ label }) => parser`
+    <span class="chip-container ${typos.display.medium[12]}">
+        ${Icon({ name: "arrowBoth", size: "md", strokeColor: colors.text.default })} ${label}
+    </span>
+    `;

--- a/src/components/Chip/index.js
+++ b/src/components/Chip/index.js
@@ -1,7 +1,7 @@
 import { Icon } from "../../constants/icons/index.js";
-import { colors } from "../../constants/tokens/colors.js";
-import { typos } from "../../constants/tokens/typos.js";
+import { colors, typos } from "../../constants/tokens/index.js";
 import { parser } from "../../lib/jsx-runtime/index.js";
+import { Text } from "../Text/index.js";
 
 /**
  *
@@ -10,7 +10,8 @@ import { parser } from "../../lib/jsx-runtime/index.js";
  * @returns {VDOM}
  */
 export const Chip = ({ label }) => parser`
-    <span class="chip-container ${typos.display.medium[12]}">
-        ${Icon({ name: "arrowBoth", size: "md", strokeColor: colors.text.default })} ${label}
+    <span class="chip-container">
+        ${Icon({ name: "arrowBoth", size: "md", strokeColor: colors.text.default })}
+        ${Text({ text: label, typo: typos.display.medium[12] })}
     </span>
     `;

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -1,0 +1,11 @@
+import { typos } from "../../constants/tokens/typos.js";
+import { parser } from "../../lib/jsx-runtime/index.js";
+
+/**
+ *
+ * @param {object} props - 텍스트 컴포넌트의 props
+ * @param {string} props.text - 표시할 텍스트
+ * @param {string} [props.typo] - 텍스트의 타이포 클래스명
+ * @returns {VDOM} - 생성된 텍스트 가상돔
+ */
+export const Text = ({ text, typo = typos.display.medium[14] }) => parser`<span class="text ${typo}">${text}</span>`;

--- a/src/components/Text/text.module.css
+++ b/src/components/Text/text.module.css
@@ -1,0 +1,3 @@
+.text {
+    padding: 0 var(--gap-50) 0 var(--gap-50);
+}

--- a/src/constants/icons/arrowBoth.js
+++ b/src/constants/icons/arrowBoth.js
@@ -5,6 +5,6 @@ import { parser } from "../../lib/jsx-runtime/index.js";
  */
 export const arrowBoth = () => parser`
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z" fill="#6E7191"/>
+<path d="M16.375 19V5M16.375 5L19 7.625M16.375 5L13.75 7.625M7.625 5V19M7.625 19L10.25 16.375M7.625 19L5 16.375" stroke="#6E7191" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>
 `;


### PR DESCRIPTION
## 주요 작업
- [x] `Button` 컴포넌트 구현
- [x] `Badge` 컴포넌트 구현
- [x] `Chip` 컴포넌트 구현

## 학습 키워드
`display: inline` `display: inline-flex`

## 고민과 해결과정
### P. `span` 태그의 경우 인라인 태그라 `width`값이 먹지 않음
### S. `display: inline-flex` 사용
항상 `display: flex`만을 남발하던 습관을 반성합니다..
`span` 태그의 경우 기본적으로 인라인으로 사용되는 것이 자연스럽다고 생각하여 인라인의 특성을 가지면서도 `flex`까지 활용할 수 있는 `display: inline-flex`를 사용했습니다.