### PR TITLE
[FE황유란] - card component 추가

### DIFF
--- a/src/assets/css/badge.css
+++ b/src/assets/css/badge.css
@@ -1,4 +1,4 @@
-.badge{
+.badge {
     border: 1px solid var(--color_border_default);
     border-radius: var(--number_100);
     padding: var(--number_50);
@@ -6,4 +6,8 @@
     display: flex;
     justify-content: center;
     align-items: center;
-}   
+}
+
+.badge:hover {
+    cursor: pointer;
+}

--- a/src/assets/css/card.css
+++ b/src/assets/css/card.css
@@ -1,0 +1,64 @@
+.card {
+    border-radius: var(--number_100);
+    background-color: var(--color_surface_default);
+    padding: var(--number_200);
+    box-shadow: var(--shadow_normal);
+}
+
+.card-default{
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+}
+
+.card-edit {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+}
+
+.card.card-drag {
+    box-shadow: var(--shadow_floating);
+}
+
+.card-place {
+    opacity: 30%;
+}
+
+.card-text_area{
+    display: flex;
+    flex-direction: column;
+    flex:1;
+}
+
+.card-icons{
+    display: flex;
+    flex-direction: column;
+    margin-left: var(--number_50);
+}
+
+.card-buttons{
+    display: flex;
+    gap: var(--number_100);
+}
+
+.card-icon {
+    width: 16px;
+    height: 16px;
+    margin: 6px;
+    cursor: pointer;
+}
+
+.card-title {
+    color: var(--color_text_strong);
+}
+
+.card-body {
+    color: var(--color_text_default);
+    margin-top: var(--number_100);
+}
+
+.card-author{
+    color: var(--color_text_weak);
+    margin-top: var(--number_200)
+}

--- a/src/assets/css/theme.css
+++ b/src/assets/css/theme.css
@@ -35,6 +35,7 @@
     --shadow_up: 0px, 2px, 8px, rgba(110, 128, 145, 0.32);
     --shadow_floating:0px 1px 4px rgba(110, 128, 145, 0.08),
         0px 16px 16px rgba(110, 128, 145, 0.24),
+
 }
 
 .display-bold24 {

--- a/src/components/Button/button.js
+++ b/src/components/Button/button.js
@@ -26,32 +26,21 @@ export class Button extends Component {
 
         buttonStyle += ' button-background';
         return `
-        <div class="${buttonStyle}"> 
-            ${iconTemplate}
-            <div class = "button-text">
-               ${this.text}
+            <div id = "${this.rootId}" class="${buttonStyle}"> 
+                ${iconTemplate}
+                <div class = "button-text">
+                    ${this.text}
+                </div>
             </div>
-        </div>
-    `;
+        `;
     }
 
     render(parent) {
-
-        parent.innerHTML += this.template();
-
-        for (const key in this.children) {
-            const childParent = document.querySelector(this.children[key].parentSelector);
-            this.children[key].object.render(childParent);
-        }
-
-        this.events.forEach(({ listenerName, callback }) => {
-            this.template.addEventListener(listenerName, callback);
-        });
+        super.render(parent);
     }
 
     addEvent(listenerName, callback) {
-        this.events.push({ listenerName, callback });
-
+        super.addEvent( listenerName, callback );
     }
 
 }

--- a/src/components/Button/iconButton.js
+++ b/src/components/Button/iconButton.js
@@ -26,28 +26,18 @@ export class IconButton extends Component {
         buttonStyle += ' button-background';
 
         return `
-        <div class="${buttonStyle}"> 
+        <div id = "${this.rootId}" class="${buttonStyle}"> 
             ${iconTemplate}
         </div>
     `;
     }
 
     render(parent) {
-
-        parent.innerHTML += this.template();
-
-        for (const key in this.children) {
-            const childParent = document.querySelector(this.children[key].parentSelector);
-            this.children[key].object.render(childParent);
-        }
-
-        this.events.forEach(({ listenerName, callback }) => {
-            parent.addEventListener(listenerName, callback);
-        });
+        super.render(parent);
     }
 
     addEvent(listenerName, callback) {
-        this.events.push({ listenerName, callback });
+        super.addEvent( listenerName, callback );
 
     }
 

--- a/src/components/Card/card.js
+++ b/src/components/Card/card.js
@@ -1,0 +1,84 @@
+import Component from "../component.js";
+
+export class DefaultCard extends Component {
+
+    children = {
+
+    };
+
+    events = [];
+
+    closeIconRef = "/assets/images/closed.svg";
+    editIconRef = "/assets/images/edit.svg";
+
+    constructor(title, body, author, onCloseClick = () => { 
+        console.log("!!!")
+    }, onEditClick = () => { }) {
+        super();
+        this.title = title;
+        this.body = body;
+        this.author = author;
+        this.onCloseClick = onCloseClick;
+        this.onEditClick = onEditClick;
+
+    }
+
+    template() {
+        return `
+        <div id = "${this.rootId}" class="card card-default"> 
+            <div class = "card-text_area">
+                <div class = "card-title display-bold24">
+                    ${this.title}
+                </div>
+                <div class = "card-body display-medium14">
+                    ${this.body}
+                </div>
+                <div class = "card-author display-medium12">
+                    author by ${this.author}
+                </div>
+            </div>
+            <div class = "card-icons">
+                <img src=${this.closeIconRef} alt="close-icon" class="card-icon" id = "close-icon" />
+                <img src=${this.editIconRef} alt="edit-icon" class="card-icon" id = "edit-icon" />
+            </div>
+        </div>
+    `;
+    }
+
+    render(parent) {
+
+        super.renderTree(parent);
+
+        const close = parent.querySelector("#close-icon");
+
+        if (close) {
+            close.addEventListener("click", (event) => {
+                
+                this.onCloseClick();
+                event.preventDefault();
+            });
+        }
+
+        const edit = parent.querySelector("#edit-icon");
+
+        if (edit) {
+            
+            edit.addEventListener("click", (event) => {
+                if (event.currentTarget.id === this.rootId) {
+                    event.stopPropagation();
+                    this.onEditClick();
+                }
+            }, false);
+
+        }
+
+        super.setEvents(parent);
+
+    }
+
+    addEvent(listenerName, callback) {
+        this.events.push({ listenerName, callback });
+
+    }
+
+}

--- a/src/components/Card/editCard.js
+++ b/src/components/Card/editCard.js
@@ -1,0 +1,70 @@
+import { Button } from "../Button/button.js";
+import Component from "../component.js";
+
+export class EditCard extends Component {
+
+    children = {
+        confirm:{
+            object: new Button("저장", null, "confirm-button"),
+            parentSelector: ".card-buttons"
+        },
+        dismiss:{
+            object: new Button("취소", null, "dismiss-button"),
+            parentSelector: ".card-buttons"
+        },
+    };
+
+    events = [];
+
+    closeIconRef = "/assets/images/closed.svg";
+    editIconRef = "/assets/images/edit.svg";
+
+    constructor(title, body, author,
+         onConfirm = () => {
+        console.log("!!!1");
+     }, onDismiss = () => { }) {
+        super();
+        this.title = title;
+        this.body = body;
+        this.author = author;
+        this.onConfirm = onConfirm;
+        this.onDismiss = onDismiss;
+    }
+
+    template() {
+        return `
+        <div id = "${this.rootId}" class="card card-edit"> 
+            <div class = "card-text_area">
+                <div class = "card-title display-bold24">
+                    ${this.title}
+                </div>
+                <div class = "card-body display-medium14">
+                    ${this.body}
+                </div>
+                <div class = "card-author display-medium12">
+                    author by ${this.author}
+                </div>
+            </div>
+            <div class  = "card-buttons">
+                
+            </div>
+        </div>
+    `;
+    }
+
+    render(parent) {   
+        
+        this.children.confirm.object.addEvent("click", this.onConfirm);
+        this.children.dismiss.object.addEvent("click", this.onDismiss);
+
+        super.render(parent);
+        
+
+    }
+
+    addEvent(listenerName, callback) {
+        this.events.push({ listenerName, callback });
+
+    }
+
+}

--- a/src/components/badge.js
+++ b/src/components/badge.js
@@ -21,29 +21,18 @@ export class Badge extends Component {
     template() {
 
         return `
-        <div class="badge"> 
-            ${this.num}
-        </div>
-    `;
+            <div id = "${this.rootId}" class="badge"> 
+                ${this.num}
+            </div>
+         `;
     }
 
     render(parent) {
-
-        parent.innerHTML += this.template();
-
-        for (const key in this.children) {
-            const childParent = document.querySelector(this.children[key].parentSelector);
-            this.children[key].object.render(childParent);
-        }
-
-        this.events.forEach(({ listenerName, callback }) => {
-            parent.addEventListener(listenerName, callback);
-        });
+        super.render(parent);
     }
 
     addEvent(listenerName, callback) {
-        this.events.push({ listenerName, callback });
-
+        super.addEvent( listenerName, callback );
     }
 
 }

--- a/src/components/chip.js
+++ b/src/components/chip.js
@@ -17,7 +17,7 @@ export class Chip extends Component {
     template() {
 
         return `
-        <div class="chip">
+        <div id = "${this.rootId}" class="chip">
             <img src=${this.sortIconRef} alt="icon" class="chip-icon" />
             <div class = "chip-text">
                 ${this.currentSort}
@@ -27,21 +27,11 @@ export class Chip extends Component {
     }
 
     render(parent) {
-
-        parent.innerHTML += this.template();
-
-        for (const key in this.children) {
-            const childParent = document.querySelector(this.children[key].parentSelector);
-            this.children[key].object.render(childParent);
-        }
-
-        this.events.forEach(({ listenerName, callback }) => {
-            parent.addEventListener(listenerName, callback);
-        });
+        super.render(parent);
     }
 
     addEvent(listenerName, callback) {
-        this.events.push({ listenerName, callback });
+        super.addEvent(listenerName, callback);
 
     }
 

--- a/src/components/component.js
+++ b/src/components/component.js
@@ -1,19 +1,66 @@
 
 export default class Component {
+    children = {};
+    events = [];
 
-    constructor(){
-    }
-    
-    template(){
-
-    }
-
-    render(){
-
+    constructor() {
+        this.rootId = this.generateRandomString(16);
     }
 
-    addEvent(){
+    generateRandomString(length) {
+        const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+        let result = '';
+        const charactersLength = characters.length;
 
+        for (let i = 0; i < length; i++) {
+            result += characters.charAt(Math.floor(Math.random() * charactersLength));
+        }
+
+        return result;
+    }
+
+
+    template() {
+        return '';
+    }
+
+    renderTree(parent) {
+        parent.innerHTML += this.template();
+
+        for (const key in this.children) {
+            const childParent = parent.querySelector(this.children[key].parentSelector);
+            this.children[key].object.render(childParent);
+        }
+    }
+
+    setEvents(parent) {
+        if (this.rootId) {
+            const root = parent.querySelector(`#${this.rootId}`);
+
+            if (root) {
+                this.events.forEach(({ listenerName, callback }) => {
+                    console.log(`root ${this.rootId} ${listenerName} `);
+                    console.log(root);
+                    root.addEventListener(listenerName, (event) => {
+                        console.log("rootdddddd", this.rootId);
+                        // if (event.currentTarget.id === this.rootId) {
+                        //     event.stopPropagation();
+                        //     callback();
+                        // }
+                    }, false);
+                });
+            }
+        }
+    }
+
+    render(parent) {
+        this.renderTree(parent);
+        this.setEvents(parent);
+    }
+
+    addEvent(listenerName, callback) {
+        console.log("event add!", this.rootId, listenerName);
+        this.events.push({ listenerName, callback });
     }
 
 }

--- a/src/view/app.js
+++ b/src/view/app.js
@@ -4,46 +4,37 @@ import { Column } from "./task/column/column.js";
 
 export class App extends Component {
 
-    children = {};
+    children = {
+        // header: {
+        //     object: new Header(),
+        //     parentSelector: "#header",
+        // },
+        column: {
+            object: new Column(),
+            parentSelector: "#header + .div",
+        },
+    };
     events = [];
 
     constructor() {
         super();
-        this.children = {
-            header: {
-                object: new Header(),
-                parentSelector: "#header",
-            },
-            column: {
-                object: new Column(),
-                parentSelector: "#header + .div",
-            },
-        };
     }
 
     template() {
         return `
-            <div id = "header">  </div>
-            <div class = "div">  </div>
+            <div id = "${this.rootId}">
+                <div id = "header">  </div>
+                <div class = "div">  </div>
+            </div>
         `;
     }
 
     render(parent) {
+        super.render(parent);
 
-        parent.innerHTML += this.template();
-
-        for (const key in this.children) {
-            const childParent = document.querySelector(this.children[key].parentSelector);
-            this.children[key].object.render(childParent);
-        }
-
-        this.events.forEach(({ listenerName, callback }) => {
-            parent.addEventListener(listenerName, callback);
-        });
     }
 
     addEvent(listenerName, callback) {
-        this.events.push({ listenerName, callback });
-
+        super.addEvent(listenerName, callback);
     }
 }

--- a/src/view/task/column/column.js
+++ b/src/view/task/column/column.js
@@ -1,9 +1,19 @@
+import { Button } from "../../../components/Button/button.js";
 import Component from "../../../components/component.js";
 
 export class Column extends Component{
 
 
-    children = {};
+    children = {
+        dismiss:{
+            object: new Button("취소", null, "dismiss-button"),
+            parentSelector: `#${this.rootId}`
+        },
+        confirm:{
+            object: new Button("저장", null, "confirm-button"),
+            parentSelector: `#${this.rootId}`
+        },
+    };
 
     events = []; 
 
@@ -13,26 +23,20 @@ export class Column extends Component{
 
     template() {
         return `
-            <div>Column</div>
+            <div id = "${this.rootId}">Column</div>
         `;
     }
 
     render(parent) {
 
-        parent.innerHTML += this.template();
 
-        for (const key in this.children) {
-            const childParent = document.querySelector(this.children[key].parentSelector);
-            this.children[key].object.render(childParent);
-        }
-
-        this.events.forEach(({ listenerName, callback }) => {
-            this.template.addEventListener(listenerName, callback);
-        });
+        this.children.confirm.object.addEvent("click", this.onConfirm);
+        this.children.dismiss.object.addEvent("click", this.onDismiss);
+        super.render(parent);
     }
 
     addEvent(listenerName, callback) {
-        this.events.push({listenerName, callback});
+        super.addEvent(listenerName, callback);
 
     }
     

--- a/src/view/task/header/header.js
+++ b/src/view/task/header/header.js
@@ -1,63 +1,57 @@
 import { Badge } from "../../../components/badge.js";
-import { IconButton} from "../../../components/Button/iconButton.js";
+import { IconButton } from "../../../components/Button/iconButton.js";
 import { Chip } from "../../../components/chip.js";
 import Component from "../../../components/component.js";
 import { Logo } from "./logo.js";
 
 
-export class Header extends Component{
+export class Header extends Component {
 
     children = {
+        // button: {
+        //     object: new IconButton("/assets/images/plus.svg",),
+        //     parentSelector: `#${this.rootId}`,
+        // },
+        badge: {
+            object: new Badge(4400),
+            parentSelector: `#${this.rootId}`,
+        },
+        // chip: {
+        //     object: new Chip("최신순"),
+        //     parentSelector: `#${this.rootId}`,
+        // },
         logo: {
-            object: new IconButton("/assets/images/plus.svg",),
-            parentSelector: ".div",
-        },
-        badge:{
-            object: new Badge(1100),
-            parentSelector:".div"
-        },
-        chip:{
-            object: new Chip("최신순"),
-            parentSelector:".div"
+            object: new Logo(),
+            parentSelector: `#${this.rootId}`,
         }
     };
 
-    events = []; 
+    events = [];
 
     constructor() {
         super();
-        this.setup();
-    }
-
-    setup(){
-        this.children.logo.object.addEvent("click", () => {
-            console.log("click!!");
-        });
     }
 
     template() {
         return `
-            <div class = "div">  <span> text!!! </span> </div>
+            <div id = "${this.rootId}" class = "div">  <span> text!!! </span> </div>
         `;
     }
 
     render(parent) {
+        // this.children.button.object.addEvent("click", () => {
+        //     console.log("button click!!");
+        // });
 
-        parent.innerHTML += this.template();
-    
-        for (const key in this.children) {
-            const childParent = document.querySelector(this.children[key].parentSelector);
-            this.children[key].object.render(childParent);
-        }
-
-        this.events.forEach(({ listenerName, callback }) => {
-            this.template.addEventListener(listenerName, callback);
+        this.children.badge.object.addEvent("click", () => {
+            console.log("click!!");
         });
+        super.render(parent);
+
     }
 
     addEvent(listenerName, callback) {
-        this.events.push({listenerName, callback});
-
+        super.addEvent(listenerName, callback);
     }
-    
+
 }

--- a/src/view/task/header/logo.js
+++ b/src/view/task/header/logo.js
@@ -1,37 +1,51 @@
+import { DefaultCard } from "../../../components/Card/card.js";
+import { EditCard } from "../../../components/Card/editCard.js";
 import Component from "../../../components/component.js";
 
 export class Logo extends Component {
 
-    children = {};
+    children = {
+        default:{
+            object: new DefaultCard("title", "body", "author",
+                 () => {
+                console.log("close cliek!!");
+            }, 
+            ()=>{
+                console.log("edit click!!");
+            }),
+            parentSelector: `#${this.rootId}`
+        },
+        edit:{
+            object: new EditCard("title", "body", "author", () => {
+                console.log("confirm cliek!!");
+            }, ()=>{
+                console.log("dismiss click!!");
+            }),
+            parentSelector:`#${this.rootId}`
+        }
+    };
 
     events = [];
 
     constructor() {
         super();
+        // this.children.edit.object.addEvent("click", () => {
+        //     console.log("edit card clicked!!");
+        // });
     }
 
     template() {
         return `
-            <div>Logo</div>
+            <div id = "${this.rootId}">Logo</div>
         `;
     }
 
     render(parent) {
-
-        parent.innerHTML += this.template();
-
-        for (const key in this.children) {
-            const childParent = document.querySelector(this.children[key].parentSelector);
-            this.children[key].object.render(childParent);
-        }
-
-        this.events.forEach(({ listenerName, callback }) => {
-            this.template.addEventListener(listenerName, callback);
-        });
+        super.render(parent);
     }
 
     addEvent(listenerName, callback) {
-        this.events.push({ listenerName, callback });
+       super.addEvent( listenerName, callback );
 
     }
 


### PR DESCRIPTION
## 주요 작업
- card component 추가
- 클릭 리스너 다는 중

## 학습 키워드

## 고민과 해결과정
### 전체 컴포넌트에 대한 리스너를 달 때 문제점
- 그냥 여러 태그가 나열되어 있는 컴포넌트 존재 
   -> 그냥 this.template에다가 listener를 달 수 없기에 무조건 태그 하나로 묶기로 함
- 컴포넌트 간 고유성 문제
  -> 하나의 div 안에 여러 button 컴포넌트들을 추가한다고 했을 때 이들 간 루트 태그가 겹치면 안됨
   -> 난수를 통해 rootId를 생성함으로서 컴포넌트들의 인스턴스 간의 고유성을 유지

### (해결중) 리스너가 달리지 않는 문제

``` javascript
renderTree(parent) {
        parent.innerHTML += this.template();

        for (const key in this.children) {
            const childParent = parent.querySelector(this.children[key].parentSelector);
            this.children[key].object.render(childParent);
        }
    }

    setEvents(parent) {
        if (this.rootId) {
            const root = parent.querySelector(`#${this.rootId}`);

            if (root) {
                this.events.forEach(({ listenerName, callback }) => {
                    console.log(`root ${this.rootId} ${listenerName} `);
                    console.log(root);
                    root.addEventListener(listenerName, (event) => {
                        console.log("rootdddddd", this.rootId);
                        // if (event.currentTarget.id === this.rootId) {
                        //     event.stopPropagation();
                        //     callback();
                        // }
                    }, false);
                });
            }
        }
    }

    render(parent) {
        this.renderTree(parent);
        this.setEvents(parent);
    }
```
- 상위 Component 클래스에서 render 관련 공통 작업을 진행 중 (컴포넌트 html을 추가하고 관련 리스너들을 달아주는 작업)
- 이 과정에서 동일 메서드를 통해 리스너를 달아주더라고 A 버튼은 클릭 리스너가 달리지만 B 버튼은 달리지 않는 문제 발생
   -> 순서에 상관없이 항상 마지막 클릭 리스너를 달은 요소만 실행이 되는 걸로 보아 실행과정에서 전체 클릭 리스너들이 덮어씌워지고 있는 것으로 보임
   -> 그러나    console.log(root); 에서는 click 리스너를 달아준 각각의 요소들이 잘 출력이 되고 있음 
   -> 우선은 하위 컴포넌들들이 상위 Component 클래스를 공유하는 과정에서 어떤 문제가 발생하는 것은 아닐까 의심중..
