### PR TITLE
[손영진] - 카드 생성, 수정, 삭제 기능 구현

### DIFF
--- a/css/components/task-column.css
+++ b/css/components/task-column.css
@@ -32,3 +32,8 @@
     flex-direction: row;
     align-items: center;
 }
+
+.task-column__body {
+    list-style: none;
+    padding: 0;
+}

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TASKIFY</title>
-    <link rel="stylesheet" type="text/css" href="./css/styles.css">
-</head>
-<body>
+    <link rel="stylesheet" type="text/css" href="./css/styles.css" />
+  </head>
+  <body>
     <div id="app"></div>
     <script type="module" src="js/app.js"></script>
-</body>
+  </body>
 </html>

--- a/js/components/Header/Header.js
+++ b/js/components/Header/Header.js
@@ -19,6 +19,7 @@ export default function Header() {
     children: createImg({
       src: "/assets/icons/clock.svg",
       alt: "history icon",
+      classList: "header__historyIcon",
     }),
   });
 

--- a/js/components/Main/Main.js
+++ b/js/components/Main/Main.js
@@ -1,12 +1,25 @@
 import TaskColumn from "../TaskColumn/TaskColumn.js";
+import initialTaskData from "../../stores/initialTaskData.js";
 
 export default function Main() {
-  const main = document.createElement("main");
-  main.classList.add("main");
+  const $main = document.createElement("main");
+  $main.classList.add("main");
 
-  main.appendChild(TaskColumn({ title: "해야할 일", tasks: [1, 2, 3] }));
-  main.appendChild(TaskColumn({ title: "하고 있는 일", tasks: [4, 5] }));
-  main.appendChild(TaskColumn({ title: "완료한 일", tasks: [6, 7, 8, 9] }));
+  if (!localStorage.getItem("taskData")) {
+    localStorage.setItem("taskData", JSON.stringify(initialTaskData));
+  }
 
-  return main;
+  const taskData = JSON.parse(localStorage.getItem("taskData"));
+
+  taskData.forEach((column) => {
+    $main.appendChild(
+      TaskColumn({
+        columnId: column.taskColumnId,
+        columnTitle: column.taskColumnTitle,
+        taskList: column.taskList,
+      })
+    );
+  });
+
+  return $main;
 }

--- a/js/components/TaskCard/TaskCard.js
+++ b/js/components/TaskCard/TaskCard.js
@@ -1,54 +1,64 @@
 import Button from "../Button/Button.js";
 import createImg from "../../utils/createImg.js";
+import deleteTask from "../../services/deleteTask.js";
 
-export default function TaskCard({id = 1}) {
-    const deleteBtnClickHandler = () => {
-        console.log('delete button clicked');
-        taskCard.remove();
-    }
+export default function TaskCard({ taskId, taskTitle, taskContent }) {
+  /** editBtnClickHandler: task card 수정 버튼을 클릭했을 때 호출됩니다. */
+  const editBtnClickHandler = () => {};
 
-    const editBtnClickHandler = () => {
-        console.log('edit button clicked');
-    }
-    const taskCard = document.createElement('div');
-    taskCard.className = 'task-card';
+  /** ($taskCard) -> ($taskCardDetails), ($taskCardButtons) */
+  const $taskCard = document.createElement("li");
+  $taskCard.className = "task-card";
+  $taskCard.id = `task-card-${taskId}`;
 
-    const taskCardDetails = document.createElement('div');
-    taskCardDetails.classList.add('task-card__details');
+  /** ($taskCardDetails) -> ($taskCardTitle), ($taskCardContent) */
+  const $taskCardDetails = document.createElement("div");
+  $taskCardDetails.classList.add("task-card__details");
 
-    const taskCardTitle = document.createElement('div');
-    taskCardTitle.classList.add('task-card__title', 'display-bold14', 'text-strong');
-    taskCardTitle.innerText = `title ${id}`;
-    
-    const TaskCardContent = document.createElement('div');
-    TaskCardContent.classList.add('task-card__content', 'display-medium14', 'text-default');
-    TaskCardContent.innerText = `content ${id}`
+  const $taskCardTitle = document.createElement("div");
+  $taskCardTitle.classList.add(
+    "task-card__title",
+    "display-bold14",
+    "text-strong"
+  );
+  $taskCardTitle.innerText = taskTitle;
 
-    const taskCardButtons = document.createElement('div');
-    taskCardButtons.classList.add('task-card__buttons');
+  const $TaskCardContent = document.createElement("div");
+  $TaskCardContent.classList.add(
+    "task-card__content",
+    "display-medium14",
+    "text-default"
+  );
+  $TaskCardContent.innerText = taskContent;
 
-    const deleteButton = Button({
-        format: 'icon',
-        onClick: deleteBtnClickHandler,
-        children: createImg({
-            src: '/assets/icons/closed.svg',
-            alt: 'delete button' 
-        }),
-    });
+  /** ($taskCardButtons) -> ($deleteButton), ($editButton) */
+  const $taskCardButtons = document.createElement("div");
+  $taskCardButtons.classList.add("task-card__buttons");
 
-    const editButton = Button({
-        format: 'icon',
-        onClick: editBtnClickHandler,
-        children: createImg({
-            src: '/assets/icons/edit.svg',
-            alt: 'edit button'
-        }),
-    });
+  const $deleteButton = Button({
+    format: "icon",
+    children: createImg({
+      src: "/assets/icons/closed.svg",
+      alt: "delete button",
+      classList: ["task-card__delete-button"],
+    }),
+  });
+  $deleteButton.classList.add("task-card__delete-button");
 
-    taskCardDetails.append(taskCardTitle, TaskCardContent);
-    taskCardButtons.append(deleteButton, editButton);
-    taskCard.append(taskCardDetails, taskCardButtons);
-    
-    return taskCard;
+  const $editButton = Button({
+    format: "icon",
+    onClick: editBtnClickHandler,
+    children: createImg({
+      src: "/assets/icons/edit.svg",
+      alt: "edit button",
+      classList: ["task-card__edit-button"],
+    }),
+  });
+  $editButton.classList.add("task-card__edit-button");
+
+  $taskCardDetails.append($taskCardTitle, $TaskCardContent);
+  $taskCardButtons.append($deleteButton, $editButton);
+  $taskCard.append($taskCardDetails, $taskCardButtons);
+
+  return $taskCard;
 }
-

--- a/js/components/TaskCard/TaskEditCard.js
+++ b/js/components/TaskCard/TaskEditCard.js
@@ -1,19 +1,42 @@
 import Button from "../Button/Button.js";
+import saveTask from "../../services/saveTask.js";
+import editTask from "../../services/editTask.js";
 
-export default function TaskEditCard() {
+export default function TaskEditCard({
+  columnId,
+  taskId,
+  taskTitle = "",
+  taskContent = "",
+}) {
+  /** titleChangeHandler */
   const titleChangeHandler = (event) => {
-    toggleSaveButton();
+    toggleSaveButton(event.target.closest(".task-edit-card"));
   };
 
+  /** contentChangeHandler */
   const contentChangeHandler = (event) => {
-    toggleSaveButton();
+    toggleSaveButton(event.target.closest(".task-edit-card"));
     autoResizeTextarea(event.target);
   };
 
-  const toggleSaveButton = () => {
-    const saveButton = document.querySelector(".task-edit-card__save-button");
-    const inputTitle = document.querySelector(".task-edit-card__title");
-    const inputContent = document.querySelector(".task-edit-card__content");
+  /** resetTaskEditCard: task를 저장 또는 입력을 취소하는 경우 실행됩니다. */
+  const resetTaskEditCard = (taskEditCard) => {
+    taskEditCard.style.display = "none";
+    const inputTitle = taskEditCard.querySelector(".task-edit-card__title");
+    const inputContent = taskEditCard.querySelector(".task-edit-card__content");
+
+    inputTitle.value = "";
+    inputContent.value = "";
+    inputContent.style.height = "auto";
+  };
+
+  /** toggleSaveButton: title과 content가 모두 입력되었을 때 버튼을 활성화합니다. */
+  const toggleSaveButton = (taskEditCard) => {
+    const saveButton = taskEditCard.querySelector(
+      ".task-edit-card__save-button"
+    );
+    const inputTitle = taskEditCard.querySelector(".task-edit-card__title");
+    const inputContent = taskEditCard.querySelector(".task-edit-card__content");
 
     if (inputTitle.value === "" || inputContent.value === "") {
       saveButton.setAttribute("disabled", "true");
@@ -22,65 +45,58 @@ export default function TaskEditCard() {
     }
   };
 
-  const saveHandler = () => {
-    const inputTitle = document.querySelector(".task-edit-card__title");
-    const inputContent = document.querySelector(".task-edit-card__content");
-
-    // TODO: {inputTitle, inputContent} localStorage에 저장
-    taskEditCard.style.display = "none";
-    inputTitle.value = "";
-    inputContent.value = "";
-  };
-
-  const cancelHandler = () => {
-    taskEditCard.style.display = "none";
-    inputTitle.value = "";
-    inputContent.value = "";
-  };
-
+  /** autoResizeTextarea: 입력된 콘텐츠 크기에 맞춰 입력 창의 높이를 조절합니다. */
   const autoResizeTextarea = (textarea) => {
     textarea.style.height = "auto";
     textarea.style.height = `${textarea.scrollHeight}px`;
   };
 
-  const taskEditCard = document.createElement("div");
-  taskEditCard.classList.add("task-edit-card");
+  /** showCard: taskEditCard의 display 속성을 `block`으로 변경합니다. */
+  const showTaskEditCard = () => {
+    $taskEditCard.style.display = "block";
+    $inputTitle.focus();
+  };
 
-  const inputTitle = document.createElement("input");
-  inputTitle.classList.add("task-edit-card__title", "display-bold14");
-  inputTitle.placeholder = "제목을 입력하세요";
-  inputTitle.addEventListener("input", titleChangeHandler);
+  /** create elements and set up event handlers */
+  const $taskEditCard = document.createElement("div");
+  $taskEditCard.classList.add("task-edit-card");
 
-  const inputContent = document.createElement("textarea");
-  inputContent.classList.add("task-edit-card__content");
-  inputContent.placeholder = "내용을 입력하세요";
-  inputContent.addEventListener("input", contentChangeHandler);
+  const $inputTitle = document.createElement("input");
+  $inputTitle.classList.add("task-edit-card__title", "display-bold14");
+  $inputTitle.placeholder = "제목을 입력하세요";
+  $inputTitle.addEventListener("input", titleChangeHandler);
+  $inputTitle.value = taskTitle;
 
-  const buttonsWrapper = document.createElement("div");
-  buttonsWrapper.classList.add("task-edit-card__buttons-wrapper");
+  const $inputContent = document.createElement("textarea");
+  $inputContent.classList.add("task-edit-card__content");
+  $inputContent.placeholder = "내용을 입력하세요";
+  $inputContent.addEventListener("input", contentChangeHandler);
+  $inputContent.value = taskContent;
 
-  const saveButton = Button({
+  const $buttonsWrapper = document.createElement("div");
+  $buttonsWrapper.classList.add("task-edit-card__buttons-wrapper");
+
+  const $saveButton = Button({
     format: "text",
     style: "brand",
     children: document.createTextNode("등록"),
     disabled: true,
-    onClick: saveHandler,
   });
-  saveButton.classList.add("task-edit-card__save-button");
+  $saveButton.classList.add("task-edit-card__save-button");
 
-  const cancelButton = Button({
+  const $cancelButton = Button({
     format: "text",
     children: document.createTextNode("취소"),
-    onClick: cancelHandler,
+    onClick: () => resetTaskEditCard($taskEditCard),
   });
+  $cancelButton.classList.add("task-edit-card__cancel-button");
 
-  buttonsWrapper.append(cancelButton, saveButton);
-  taskEditCard.append(inputTitle, inputContent, buttonsWrapper);
+  $buttonsWrapper.append($cancelButton, $saveButton);
+  $taskEditCard.append($inputTitle, $inputContent, $buttonsWrapper);
 
-  const showCard = () => {
-    taskEditCard.style.display = "block";
-    inputTitle.focus();
+  return {
+    taskEditCard: $taskEditCard,
+    showTaskEditCard: showTaskEditCard,
+    resetTaskEditCard: resetTaskEditCard,
   };
-
-  return { taskEditCard, showCard };
 }

--- a/js/components/TaskColumn/TaskColumn.js
+++ b/js/components/TaskColumn/TaskColumn.js
@@ -1,76 +1,132 @@
-import createImg from "../../utils/createImg.js";
-import Button from "../Button/Button.js";
-import TaskCard from "../TaskCard/TaskCard.js";
+import TaskColumnHeader from "./TaskColumnHeader/TaskColumnHeader.js";
 import TaskEditCard from "../TaskCard/TaskEditCard.js";
+import TaskColumnBody from "./TaskColumnBody/TaskColumnBody.js";
+import saveTask from "../../services/saveTask.js";
+import deleteTask from "../../services/deleteTask.js";
+import editTask from "../../services/editTask.js";
 
-export default function TaskColumn({ title, tasks = [1, 2, 3] }) {
-  const column = document.createElement("div");
-  column.classList.add("task-column");
+export default function TaskColumn({ columnId, columnTitle, taskList = [] }) {
+  const $column = document.createElement("div");
+  $column.classList.add("task-column");
 
-  /** (columnHeader) -> (columnInfo), (columnButtonsWrapper) */
-  const columnHeader = document.createElement("div");
-  columnHeader.classList.add("task-column__header");
+  /** event listener */
+  $column.addEventListener("click", (event) => {
+    const target = event.target;
+    const classList = target.classList;
 
-  /** (columnInfo) -> (columnTitle), (columnTasksNum) */
-  const columnInfo = document.createElement("div");
-  columnInfo.classList.add("task-column__info");
+    // 새로운 작업 추가
+    if (classList.contains(`task-edit-card__save-button`)) {
+      const $taskEditCard = target.closest(`.task-edit-card`);
+      if (!$taskEditCard.dataset.taskId) {
+        const $inputTitle = $taskEditCard?.querySelector(
+          `.task-edit-card__title`
+        );
+        const $inputContent = $taskEditCard?.querySelector(
+          `.task-edit-card__content`
+        );
 
-  const columnTitle = document.createElement("div");
-  columnTitle.classList.add("display-bold16", "text-bold");
-  columnTitle.innerText = title;
+        saveTask({
+          columnId,
+          taskTitle: $inputTitle.value,
+          taskContent: $inputContent.value,
+          taskEditCard: $taskEditCard,
+        });
+        taskEditCardInstance.resetTaskEditCard($taskEditCard);
+      }
+    }
+    // 작업 추가/수정 취소
+    else if (classList.contains(`task-edit-card__cancel-button`)) {
+      const $taskEditCard = target.closest(`.task-edit-card`);
+      const taskId = $taskEditCard.dataset.taskId;
 
-  const columnTasksNum = document.createElement("div");
-  columnTasksNum.classList.add(
-    "task-column__tasks-num",
-    "border-default",
-    "text-weak",
-    "display-medium12"
-  );
-  columnTasksNum.innerText = tasks.length;
+      if (taskId) {
+        // 수정 중이었던 경우: 원래 TaskCard로 복구
+        const taskTitle = $taskEditCard.dataset.originalTitle;
+        const taskContent = $taskEditCard.dataset.originalContent;
 
-  /** (columnButtonWrapper) -> (addTaskButton), (deleteColumnButton) */
-  const columnButtonsWrapper = document.createElement("div");
-  columnButtonsWrapper.classList.add("task-column__buttons-wrapper");
+        const $originalTaskCard = TaskCard({
+          taskId: Number(taskId),
+          taskTitle,
+          taskContent,
+        });
 
-  const taskEditCardInstance = TaskEditCard();
-  const taskEditCard = taskEditCardInstance.taskEditCard;
-  taskEditCard.style.display = "none";
+        $taskEditCard.replaceWith($originalTaskCard);
+      } else {
+        // 새로운 작업 추가 중이었던 경우: 입력 폼 초기화
+        taskEditCardInstance.resetTaskEditCard($taskEditCard);
+      }
+    }
+    // task card 삭제
+    else if (classList.contains(`task-card__delete-button`)) {
+      const $taskCard = target.closest(`.task-card`);
+      const taskId = $taskCard.id.slice(10);
+      deleteTask({ taskId: Number(taskId) });
+      $taskCard.remove();
+    }
+    // task card 수정
+    else if (classList.contains(`task-card__edit-button`)) {
+      const $taskCard = target.closest(`.task-card`);
+      const taskId = Number($taskCard.id.slice(10));
+      const taskTitle = $taskCard.querySelector(`.task-card__title`).innerText;
+      const taskContent =
+        $taskCard.querySelector(`.task-card__content`).innerText;
+
+      const editCardInstance = TaskEditCard({
+        columnId,
+        taskId,
+        taskTitle,
+        taskContent,
+      });
+
+      // 수정 중임을 표시하기 위해 taskId와 원본 데이터를 data 속성으로 추가
+      editCardInstance.taskEditCard.dataset.taskId = taskId;
+      editCardInstance.taskEditCard.dataset.originalTitle = taskTitle;
+      editCardInstance.taskEditCard.dataset.originalContent = taskContent;
+
+      $taskCard.replaceWith(editCardInstance.taskEditCard);
+      editCardInstance.showTaskEditCard();
+
+      editCardInstance.taskEditCard
+        .querySelector(".task-edit-card__save-button")
+        .addEventListener("click", () => {
+          editTask({
+            columnId,
+            taskId,
+            taskEditCard: editCardInstance.taskEditCard,
+            $taskCard,
+          });
+        });
+    }
+  });
+
+  const taskEditCardInstance = TaskEditCard({ columnId });
+  const $taskEditCard = taskEditCardInstance.taskEditCard;
+  $taskEditCard.style.display = "none";
 
   const addTaskHandler = () => {
     console.log("add task");
-    taskEditCard.style.display = "block";
-    taskEditCardInstance.showCard();
+    $taskEditCard.style.display = "block";
+    taskEditCardInstance.showTaskEditCard();
   };
 
   const deleteColumnHandler = () => {
     console.log("delete column");
   };
 
-  const addTaskButton = Button({
-    format: "icon",
-    children: createImg({
-      src: "/assets/icons/plus.svg",
-      alt: "task add button",
-    }),
-    onClick: addTaskHandler,
+  const $taskColumnHeader = TaskColumnHeader({
+    columnTitle,
+    taskListLength: taskList.length,
+    onAddTask: addTaskHandler,
+    onDeleteColumn: deleteColumnHandler,
   });
 
-  const deleteColumnButton = Button({
-    format: "icon",
-    children: createImg({
-      src: "/assets/icons/closed.svg",
-    }),
-    onClick: deleteColumnHandler,
+  const $taskColumnBody = TaskColumnBody({
+    columnId,
+    taskList,
+    taskEditCard: $taskEditCard,
   });
 
-  columnInfo.append(columnTitle, columnTasksNum);
-  columnButtonsWrapper.append(addTaskButton, deleteColumnButton);
-  columnHeader.append(columnInfo, columnButtonsWrapper);
-  column.append(columnHeader, taskEditCard);
+  $column.append($taskColumnHeader, $taskColumnBody);
 
-  for (const taskId of tasks) {
-    column.append(TaskCard({ id: taskId }));
-  }
-
-  return column;
+  return $column;
 }

--- a/js/components/TaskColumn/TaskColumnBody/TaskColumnBody.js
+++ b/js/components/TaskColumn/TaskColumnBody/TaskColumnBody.js
@@ -1,0 +1,18 @@
+import deleteTask from "../../../services/deleteTask.js";
+import TaskCard from "../../TaskCard/TaskCard.js";
+
+export default function TaskColumnBody({ columnId, taskList, taskEditCard }) {
+  const $columnBody = document.createElement("ol");
+  $columnBody.classList.add("task-column__body");
+
+  if (taskEditCard) {
+    $columnBody.appendChild(taskEditCard);
+  }
+
+  for (const { taskId, taskTitle, taskContent } of taskList) {
+    console.log(taskId, taskTitle, taskContent);
+    $columnBody.append(TaskCard({ columnId, taskId, taskTitle, taskContent }));
+  }
+
+  return $columnBody;
+}

--- a/js/components/TaskColumn/TaskColumnHeader/TaskColumnHeader.js
+++ b/js/components/TaskColumn/TaskColumnHeader/TaskColumnHeader.js
@@ -1,0 +1,56 @@
+import Button from "../../Button/Button.js";
+import createImg from "../../../utils/createImg.js";
+
+export default function TaskColumnHeader({
+  columnTitle,
+  taskListLength,
+  onAddTask,
+  onDeleteColumn,
+}) {
+  const $columnHeader = document.createElement("div");
+  $columnHeader.classList.add("task-column__header");
+
+  /** (columnInfo) -> (columnTitle), (columnTasksNum) */
+  const $columnInfo = document.createElement("div");
+  $columnInfo.classList.add("task-column__info");
+
+  const $columnTitle = document.createElement("div");
+  $columnTitle.classList.add("display-bold16", "text-bold");
+  $columnTitle.innerText = columnTitle;
+
+  const $columnTasksNum = document.createElement("div");
+  $columnTasksNum.classList.add(
+    "task-column__tasks-num",
+    "border-default",
+    "text-weak",
+    "display-medium12"
+  );
+  $columnTasksNum.innerText = taskListLength;
+
+  /** (columnButtonWrapper) -> (addTaskButton), (deleteColumnButton) */
+  const $columnButtonsWrapper = document.createElement("div");
+  $columnButtonsWrapper.classList.add("task-column__buttons-wrapper");
+
+  const $addTaskButton = Button({
+    format: "icon",
+    children: createImg({
+      src: "/assets/icons/plus.svg",
+      alt: "task add button",
+    }),
+    onClick: onAddTask,
+  });
+
+  const $deleteColumnButton = Button({
+    format: "icon",
+    children: createImg({
+      src: "/assets/icons/closed.svg",
+    }),
+    onClick: onDeleteColumn,
+  });
+
+  $columnInfo.append($columnTitle, $columnTasksNum);
+  $columnButtonsWrapper.append($addTaskButton, $deleteColumnButton);
+  $columnHeader.append($columnInfo, $columnButtonsWrapper);
+
+  return $columnHeader;
+}

--- a/js/services/deleteTask.js
+++ b/js/services/deleteTask.js
@@ -1,0 +1,17 @@
+import { getTaskData, setTaskData } from "../stores/TaskDataStore.js";
+
+export default function deleteTask({ taskId }) {
+  const taskData = getTaskData();
+
+  const columnIndex = taskData.findIndex((column) =>
+    column.taskList.some((task) => task.taskId === taskId)
+  );
+
+  if (columnIndex !== -1) {
+    taskData[columnIndex].taskList = taskData[columnIndex].taskList.filter(
+      (task) => task.taskId !== taskId
+    );
+
+    setTaskData(taskData);
+  }
+}

--- a/js/services/editTask.js
+++ b/js/services/editTask.js
@@ -1,0 +1,27 @@
+import TaskDataStore from "../stores/TaskDataStore.js";
+
+export default function editTask({
+  columnId,
+  taskId,
+  taskEditCard,
+  $taskCard,
+}) {
+  const $inputTitle = taskEditCard.querySelector(".task-edit-card__title");
+  const $inputContent = taskEditCard.querySelector(".task-edit-card__content");
+
+  // TaskDataStore를 통해 task 수정
+  TaskDataStore.editTask({
+    columnId,
+    taskId,
+    taskTitle: $inputTitle.value,
+    taskContent: $inputContent.value,
+  });
+
+  // 기존 카드의 내용만 업데이트
+  $taskCard.querySelector(".task-card__title").innerText = $inputTitle.value;
+  $taskCard.querySelector(".task-card__content").innerText =
+    $inputContent.value;
+
+  // 수정 카드를 기존 카드로 교체
+  taskEditCard.replaceWith($taskCard);
+}

--- a/js/services/saveTask.js
+++ b/js/services/saveTask.js
@@ -1,0 +1,52 @@
+import TaskCard from "../components/TaskCard/TaskCard.js";
+import { getTaskData, setTaskData } from "../stores/TaskDataStore.js";
+
+export default function saveTask({
+  columnId,
+  taskId,
+  taskTitle,
+  taskContent,
+  taskEditCard,
+}) {
+  const taskData = getTaskData();
+  const columnIndex = taskData.findIndex(
+    (column) => column.taskColumnId === columnId
+  );
+
+  if (columnIndex === -1) return;
+
+  // taskId가 있으면 기존 task 수정
+  if (taskId) {
+    const taskIndex = taskData[columnIndex].taskList.findIndex(
+      (task) => task.taskId === taskId
+    );
+    console.log("taskindex: ", taskIndex);
+    if (taskIndex !== -1) {
+      taskData[columnIndex].taskList[taskIndex].taskTitle = taskTitle;
+      taskData[columnIndex].taskList[taskIndex].taskContent = taskContent;
+    }
+  } else {
+    const newTask = {
+      taskId: Date.now(),
+      taskTitle,
+      taskContent,
+    };
+    taskData[columnIndex].taskList.push(newTask);
+  }
+
+  setTaskData(taskData);
+
+  const $taskColumnBody = taskEditCard.closest(".task-column__body");
+  const $taskCard = TaskCard({
+    taskId: taskId || Date.now(),
+    taskTitle,
+    taskContent,
+  });
+
+  // taskId가 있으면 기존 카드를 교체, 없으면 새로 추가
+  if (taskId) {
+    taskEditCard.replaceWith($taskCard);
+  } else {
+    $taskColumnBody.appendChild($taskCard);
+  }
+}

--- a/js/stores/TaskDataStore.js
+++ b/js/stores/TaskDataStore.js
@@ -1,0 +1,35 @@
+export function setTaskData(data) {
+  localStorage.setItem("taskData", JSON.stringify(data));
+}
+
+export function getTaskData() {
+  return JSON.parse(localStorage.getItem("taskData")) || [];
+}
+
+class TaskDataStore {
+  editTask({ columnId, taskId, taskTitle, taskContent }) {
+    const taskData = getTaskData();
+    const columnIndex = taskData.findIndex(
+      (column) => column.taskColumnId === columnId
+    );
+
+    if (columnIndex !== -1) {
+      const taskList = taskData[columnIndex].taskList;
+      const taskIndex = taskList.findIndex((task) => task.taskId === taskId);
+
+      if (taskIndex !== -1) {
+        // task 데이터 업데이트
+        taskData[columnIndex].taskList[taskIndex] = {
+          ...taskList[taskIndex],
+          taskTitle,
+          taskContent,
+        };
+
+        // 로컬스토리지 업데이트
+        setTaskData(taskData);
+      }
+    }
+  }
+}
+
+export default new TaskDataStore();

--- a/js/stores/initialTaskData.js
+++ b/js/stores/initialTaskData.js
@@ -1,0 +1,19 @@
+const initialTaskData = [
+  {
+    taskColumnId: 1,
+    taskColumnTitle: "해야할 일",
+    taskList: [],
+  },
+  {
+    taskColumnId: 2,
+    taskColumnTitle: "하고 있는 일",
+    taskList: [],
+  },
+  {
+    taskColumnId: 3,
+    taskColumnTitle: "완료한 일",
+    taskList: [],
+  },
+];
+
+export default initialTaskData;

--- a/js/utils/createImg.js
+++ b/js/utils/createImg.js
@@ -1,7 +1,10 @@
-export default function createImg ({ src, alt }) {
-    const icon = document.createElement('img');
-    icon.src = src;
-    icon.alt = alt;
+export default function createImg({ src, alt, classList = [] }) {
+  const iconImg = document.createElement("img");
+  iconImg.src = src;
+  iconImg.alt = alt;
+  for (const c of classList) {
+    iconImg.classList.add(c);
+  }
 
-    return icon;
+  return iconImg;
 }


### PR DESCRIPTION
## 주요 작업
- [x] 카드 생성 기능
- [x] 카드 삭제 기능
- [x] 카드 수정 기능


## 학습 키워드
- 이벤트 위임
- closest

## 고민과 해결과정
- 이벤트를 어디서 등록할 것인가?
이벤트 위임을 활용하여, 상위 컨테이너인 TaskColumn에 이벤트를 등록하고, 이벤트가 발생한 요소가 버튼인지 확인한 후 해당 작업을 처리하도록 구현했습니다. 아직 코드를 정리하지는 못했지만, 해당 방법을 통해 기존에 일일이 돔 요소를 일일이 찾아서 조작해야 했던 번거로움을 줄일 수 있었습니다.

- 첫 번째 이후 칼럼에서 task를 등록할 수 없는 문제
첫 번째 칼럼에서는 카드 등록이 정상적으로 작동했지만, 다른 칼럼에서는 카드를 등록할 수 없는 문제가 발생했습니다. 문제의 원인은 **`querySelector`로 요소를 찾을 때 DOM 전체에서 첫 번째로 일치하는 요소**만 선택되어, 첫 번째 칼럼의 `taskEditCard`만 제대로 작동했기 때문입니다. 이를 해결하기 위해 **`closest`** 메서드를 사용하여 클릭된 요소에서 가장 가까운 **`taskEditCard`** 부모 요소를 찾도록 수정했습니다. `closest`는 지정한 선택자와 일치하는 가장 가까운 부모 요소를 반환하므로, 각 카드의 상태를 독립적으로 관리할 수 있게 되었습니다. 이를 통해 모든 칼럼에서 카드를 정상적으로 등록할 수 있게 되었습니다.