### PR TITLE
[dioo1461] - 카드 드래그 기능 구현

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         </section>
     </template>
 
-    <template id="todo-item-form-template">
+    <template id="todo-item-add-form-template">
         <section class="todos__add-form">
             <input
                 class="todos__add-form__input-title"
@@ -62,6 +62,29 @@
                 </button>
                 <button class="todos__add-form__submit-btn" type="button">
                     등록
+                </button>
+            </div>
+        </section>
+    </template>
+
+    <template id="todo-item-edit-form-template">
+        <section class="todos__add-form">
+            <input
+                class="todos__add-form__input-title"
+                type="text"
+                placeholder="제목을 입력하세요"
+            />
+            <input
+                class="todos__add-form__input-content"
+                type="text"
+                placeholder="내용을 입력하세요"
+            />
+            <div class="todos__add-form__button-container">
+                <button class="todos__add-form__cancel-btn" type="button">
+                    취소
+                </button>
+                <button class="todos__add-form__submit-btn" type="button">
+                    저장
                 </button>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
     </template>
 
     <template id="todo-item-template">
-        <li class="todos__body__item">
+        <li class="todos__body__item" draggable="true">
             <div class="todos__body__item__left-container">
                 <div>
                     <div class="todos__body__item__title">GitHub 공부하기</div>
@@ -110,6 +110,10 @@
                 </button>
             </div>
         </li>
+    </template>
+
+    <template id="todo-item-skeleton">
+        <li class="todos__body__item"></li>
     </template>
 
     <template id="acativity-history-template">

--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
     </template>
 
     <template id="todo-item-skeleton">
-        <li class="todos__body__item"></li>
+        <li class="todos__body__item skeleton"></li>
     </template>
 
     <template id="acativity-history-template">

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -206,11 +206,11 @@ const editTodoItem = (identifier) => {
             component
                 .querySelector(`.${classNames.todoEditFormSubmitBtn}`)
                 .addEventListener('click', () => {
-                    const element = findDomElement(identifier)
-                    const title = element.querySelector(
+                    const editFormElement = findDomElement(identifier)
+                    const title = editFormElement.querySelector(
                         `.${classNames.todoEditFormInputTitle}`
                     ).value
-                    const content = element.querySelector(
+                    const content = editFormElement.querySelector(
                         `.${classNames.todoEditFormInputContent}`
                     ).value
                     // TODO: author 정보 동적으로 가져오기
@@ -218,7 +218,7 @@ const editTodoItem = (identifier) => {
 
                     replaceDomElement(
                         templateNames.todoItem,
-                        element,
+                        editFormElement,
                         (identifier, component) => {
                             const editedTodoItem = TodoItem(
                                 identifier,

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -26,6 +26,10 @@ export const initTodo = () => {
     // storeData(TODO_CATEGORY_KEY, categoryList)
 
     const mainElement = document.querySelector('.main')
+    let currentCategory = null
+    let currentIndex = null
+    let skeletonElementId = null
+
     categoryList.map((category) => {
         const categoryId = createDomElementAsChild(
             templateNames.todoHeader,
@@ -43,10 +47,6 @@ export const initTodo = () => {
                         onAddTodoButtonClick(category)
                     })
 
-                let currentCategory = null
-                let currentIndex = null
-                let skeletonElement = null
-
                 component.addEventListener('dragover', (e) => {
                     // 드롭을 허용하기 위해 기본 동작 취소
                     e.preventDefault()
@@ -56,6 +56,8 @@ export const initTodo = () => {
                     e.preventDefault()
                 })
                 component.addEventListener('dragenter', (e) => {
+                    // if (!e.target.contains(`.${classNames.todoItemBody}`))
+                    //     return
                     const categoryList = getState(TODO_CATEGORY_KEY)
                     for (let category of categoryList) {
                         // 카테고리 식별
@@ -72,21 +74,32 @@ export const initTodo = () => {
                         ] of category.values.todoList.entries()) {
                             if (todoItem.identifier === e.target.id) {
                                 currentIndex = idx
-                                console.log(
-                                    `currentCategory: ${currentCategory}, currentIndex: ${currentIndex}`
-                                )
                                 break
                             }
                         }
-
-                        if (currentIndex === null) {
+                        if (e.target.className === classNames.todoContainer) {
                             currentIndex = category.values.todoList.length
                         }
+                        // 자식 요소에 이벤트 전달되면 null값이 들어감...
+                        if (currentIndex === null) {
+                            return
+                        }
+                        console.log('dragenter', currentCategory, currentIndex)
                     }
                 })
-                component.addEventListener('dragleave', (e) => {
-                    // console.log('dragleave', e.target)
-                })
+                component.addEventListener(
+                    'dragleave',
+                    (e) => {
+                        // if (currentCategory === identifier) return
+                        // if (e.target.id !== identifier) return
+                        console.log('dragleave')
+                        e.stopPropagation()
+                        findDomElement(identifier)
+                            .querySelector(`.${classNames.skeleton}`)
+                            .remove()
+                    },
+                    true
+                )
             }
         )
         category.identifier = categoryId

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -8,56 +8,82 @@ import {
 } from '../utils/domUtil.js'
 import { classNames, templateNames } from '../strings.js'
 import { TodoItem } from '../domain/todoItem.js'
+import { Category } from '../domain/Category.js'
 
-const TODO_LIST_STORAGE_KEY = 'todoList'
-const TODO_FORM_DOM_ID_KEY = 'isCreatingTodo'
-
-const mockedUpCategories = ['해야할 일', '하고 있는 일', '완료한 일']
+// const TODO_LIST_STORAGE_KEY = 'todoList'
+const TODO_CATEGORY_KEY = 'todoCategory'
+// const TODO_FORM_DOM_ID_KEY = 'isCreatingTodo'
 
 export const initTodo = () => {
+    let categoryList = loadData(TODO_CATEGORY_KEY)
+    if (!categoryList) {
+        storeData(TODO_CATEGORY_KEY, [])
+        categoryList = []
+    }
+
+    // 더미 데이터
+    // categoryList = [Category(-1, '해야할 일'), Category(-1, '하고 있는 일')]
+    // storeData(TODO_CATEGORY_KEY, categoryList)
+
     const todoHeaderParentElement = document.querySelector('.main')
-    mockedUpCategories.forEach((category) => {
-        const headerId = createDomElementAsChild(
+    categoryList.map((category) => {
+        const categoryId = createDomElementAsChild(
             templateNames.todoHeader,
             todoHeaderParentElement
         )
-        const element = findDomElement(headerId)
+        category.identifier = categoryId
+        category.todoFormDomId = null
+
+        const element = findDomElement(categoryId)
         element.querySelector(`.${classNames.todoHeaderTitle}`).textContent =
-            category
+            category.values.category
         element
             .querySelector(`.${classNames.addButton}`)
             .addEventListener('click', () => {
-                onAddTodoButtonClick()
+                onAddTodoButtonClick(category)
             })
+
+        category.values.todoList.map((todoItem) => {
+            const todoElementId = createDomElementAsChild(
+                templateNames.todoItem,
+                findDomElement(categoryId).querySelector(
+                    `.${classNames.todoBody}`
+                )
+            )
+            todoItem.identifier = todoElementId
+            const todoElement = findDomElement(todoElementId)
+            initTodoItemElement(todoElement, todoItem)
+            // identifier 변경을 todoList에 반영
+            return todoItem
+        })
+
+        // identifier 변경을 categoryList에 반영
+        return category
     })
 
-    setState(TODO_FORM_DOM_ID_KEY, false)
-    const storedTodoList = loadData(TODO_LIST_STORAGE_KEY)
-    storeData(TODO_LIST_STORAGE_KEY, [])
-    storedTodoList?.reverse().forEach((todo) => {
-        addTodoItem(todo.values.title, todo.values.content, todo.values.author)
-    })
+    setState(TODO_CATEGORY_KEY, categoryList)
 }
 
-export const onAddTodoButtonClick = () => {
-    const isCreatingTodo = getState(TODO_FORM_DOM_ID_KEY)
-    if (isCreatingTodo) {
-        disableAddTodoForm()
+export const onAddTodoButtonClick = (category) => {
+    if (category.todoFormDomId) {
+        disableAddTodoForm(category)
     } else {
-        enableAddTodoForm()
+        enableAddTodoForm(category)
     }
 }
 
 // TODO: form이 비어 있으면 submit 버튼 비활성화
-const enableAddTodoForm = () => {
-    const parentDomElement = document.querySelector('.todos__body')
+const enableAddTodoForm = (category) => {
+    const parentDomElement = findDomElement(category.identifier).querySelector(
+        `.${classNames.todoBody}`
+    )
     const formId = createDomElementAsChild(
         templateNames.todoItemAddForm,
         parentDomElement,
         false
     )
-
-    setState(TODO_FORM_DOM_ID_KEY, formId)
+    category.todoFormDomId = formId
+    // setState(TODO_FORM_DOM_ID_KEY, formId)
     const formElement = findDomElement(formId)
     formElement
         .querySelector(`.${classNames.todoAddFormSubmitBtn}`)
@@ -69,24 +95,25 @@ const enableAddTodoForm = () => {
                 `.${classNames.todoAddFormInputContent}`
             ).value
             const author = 'web'
-            addTodoItem(title, content, author)
+            addTodoItem(title, content, author, category)
             removeDomElement(formId)
-            setState(TODO_FORM_DOM_ID_KEY, null)
+            // setState(TODO_FORM_DOM_ID_KEY, null)
         })
     formElement
         .querySelector(`.${classNames.todoAddFormCancelBtn}`)
         .addEventListener('click', () => {
             removeDomElement(formId)
-            setState(TODO_FORM_DOM_ID_KEY, null)
+            // setState(TODO_FORM_DOM_ID_KEY, null)
         })
 }
 
-const disableAddTodoForm = () => {
-    removeDomElement(getState(TODO_FORM_DOM_ID_KEY))
-    setState(TODO_FORM_DOM_ID_KEY, null)
+const disableAddTodoForm = (category) => {
+    removeDomElement(category.todoFormDomId)
+    category.todoFormDomId = null
+    // setState(TODO_FORM_DOM_ID_KEY, null)
 }
 
-const initTodoItem = (todoElement, todoItem) => {
+const initTodoItemElement = (todoElement, todoItem) => {
     const {
         identifier,
         values: { title, content, author },
@@ -99,7 +126,7 @@ const initTodoItem = (todoElement, todoItem) => {
     todoElement.querySelector(
         `.${classNames.todoItemAuthor}`
     ).textContent = `author by ${author}`
-
+    // category 정보 어떻게 얻어올 것인지 ?
     todoElement
         .querySelector(`.${classNames.deleteButton}`)
         .addEventListener('click', () => {
@@ -112,41 +139,50 @@ const initTodoItem = (todoElement, todoItem) => {
         })
 }
 
-const addTodoItem = (title, content, author) => {
+const addTodoItem = (title, content, author, category) => {
     // TODO: 하드코딩된 부모 클래스명 변경
-    const parentDomElement = document.querySelector('.todos__body')
+    const parentDomElement = findDomElement(category.identifier).querySelector(
+        '.todos__body'
+    )
     const identifier = createDomElementAsChild(
         templateNames.todoItem,
         parentDomElement,
         false
     )
 
-    const prevTodoList = loadData(TODO_LIST_STORAGE_KEY)
     const todoItem = TodoItem(identifier, title, content, author)
-    prevTodoList.unshift(todoItem)
-    storeData(TODO_LIST_STORAGE_KEY, prevTodoList)
+    category.values.todoList.unshift(todoItem)
+    // setState(TODO_CATEGORY_KEY, category)
+    // category 객체를 참조하므로 setState를 안 해도 변경이 되긴 함 .. 맘에 안들지만 일단은 이렇게
+    storeData(TODO_CATEGORY_KEY, getState(TODO_CATEGORY_KEY))
 
     const element = findDomElement(identifier)
-    initTodoItem(element, todoItem)
+    initTodoItemElement(element, todoItem)
 }
 
-// const createCategory = (categoryName) => {}
+const getTodoItemInfo = (identifier) => {
+    const categoryList = getState(TODO_CATEGORY_KEY)
+    for (let category of categoryList) {
+        for (let [idx, todo] of category.values.todoList.entries()) {
+            if (todo.identifier === identifier) {
+                return { category: category, index: idx, todoItem: todo }
+            }
+        }
+    }
+    return null
+}
 
 const removeTodoItem = (identifier) => {
-    const prevTodoList = loadData(TODO_LIST_STORAGE_KEY)
-    const targetIdx = prevTodoList.findIndex(
-        (todo) => todo.identifier === identifier
-    )
-    prevTodoList.splice(targetIdx, 1)
+    const { category, index, todoItem } = getTodoItemInfo(identifier)
+    category.values.todoList.splice(index, 1)
     removeDomElement(identifier)
-    storeData(TODO_LIST_STORAGE_KEY, prevTodoList)
+    storeData(TODO_CATEGORY_KEY, getState(TODO_CATEGORY_KEY))
 }
 
 const editTodoItem = (identifier) => {
-    const todoList = loadData(TODO_LIST_STORAGE_KEY)
-    const targetIdx = todoList.findIndex(
-        (todo) => todo.identifier === identifier
-    )
+    const { category, index: targetIdx, todoItem } = getTodoItemInfo(identifier)
+    const todoList = category.values.todoList
+
     const originTodoItem = todoList[targetIdx]
     const {
         title: originTitle,
@@ -174,6 +210,7 @@ const editTodoItem = (identifier) => {
             const content = formElement.querySelector(
                 `.${classNames.todoEditFormInputContent}`
             ).value
+            // TODO: author 정보 동적으로 가져오기
             const author = 'web'
 
             const editedTodoElementId = replaceDomElement(
@@ -181,17 +218,17 @@ const editTodoItem = (identifier) => {
                 formElement
             )
 
-            const newTodoItem = TodoItem(
+            const editedTodoItem = TodoItem(
                 editedTodoElementId,
                 title,
                 content,
                 author
             )
             const editedTodoElement = findDomElement(editedTodoElementId)
-            initTodoItem(editedTodoElement, newTodoItem)
+            initTodoItemElement(editedTodoElement, editedTodoItem)
 
-            todoList[targetIdx] = newTodoItem
-            storeData(TODO_LIST_STORAGE_KEY, todoList)
+            todoList[targetIdx] = editedTodoItem
+            storeData(TODO_CATEGORY_KEY, getState(TODO_CATEGORY_KEY))
         })
     formElement
         .querySelector(`.${classNames.todoEditFormCancelBtn}`)
@@ -207,16 +244,7 @@ const editTodoItem = (identifier) => {
                 originContent,
                 originAuthor
             )
-            initTodoItem(abortedTodoItemElement, abortedTodoItem)
+            initTodoItemElement(abortedTodoItemElement, abortedTodoItem)
             todoList[targetIdx] = abortedTodoItem
-            storeData(TODO_LIST_STORAGE_KEY, todoList)
         })
-}
-
-const findTodoItem = (identifier) => {
-    const todoList = loadData(TODO_LIST_STORAGE_KEY)
-    const targetIdx = todoList.findIndex(
-        (todo) => todo.identifier === identifier
-    )
-    return { index: index, value: todoList[targetIdx] }
 }

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -1,14 +1,13 @@
-import { setState, getState } from '../utils/stateUtil.js'
-import { storeData, loadData } from '../utils/storageUtil.js'
+import { TodoItem } from '../domain/todoItem.js'
+import { classNames, templateNames } from '../strings.js'
 import {
     createDomElementAsChild,
     findDomElement,
     removeDomElement,
     replaceDomElement,
 } from '../utils/domUtil.js'
-import { classNames, templateNames } from '../strings.js'
-import { TodoItem } from '../domain/todoItem.js'
-import { Category } from '../domain/Category.js'
+import { getState, setState } from '../utils/stateUtil.js'
+import { loadData, storeData } from '../utils/storageUtil.js'
 
 // const TODO_LIST_STORAGE_KEY = 'todoList'
 const TODO_CATEGORY_KEY = 'todoCategory'
@@ -58,6 +57,7 @@ export const initTodo = () => {
             return todoItem
         })
 
+        renewTodoCount(category)
         // identifier 변경을 categoryList에 반영
         return category
     })
@@ -65,7 +65,7 @@ export const initTodo = () => {
     setState(TODO_CATEGORY_KEY, categoryList)
 }
 
-export const onAddTodoButtonClick = (category) => {
+const onAddTodoButtonClick = (category) => {
     if (category.todoFormDomId) {
         disableAddTodoForm(category)
     } else {
@@ -146,7 +146,7 @@ const addTodoItem = (title, content, author, category) => {
     const parentDomElement = findDomElement(category.identifier).querySelector(
         '.todos__body'
     )
-    const identifier = createDomElementAsChild(
+    createDomElementAsChild(
         templateNames.todoItem,
         parentDomElement,
         (identifier, component) => {
@@ -160,6 +160,7 @@ const addTodoItem = (title, content, author, category) => {
     // setState(TODO_CATEGORY_KEY, category)
     // category 객체를 참조하므로 setState를 안 해도 변경이 되긴 함 .. 맘에 안들지만 일단은 이렇게
     storeData(TODO_CATEGORY_KEY, getState(TODO_CATEGORY_KEY))
+    renewTodoCount(category)
 }
 
 const getTodoItemInfo = (identifier) => {
@@ -178,6 +179,7 @@ const removeTodoItem = (identifier) => {
     const { category, index, todoItem } = getTodoItemInfo(identifier)
     category.values.todoList.splice(index, 1)
     removeDomElement(identifier)
+    renewTodoCount(category)
     storeData(TODO_CATEGORY_KEY, getState(TODO_CATEGORY_KEY))
 }
 
@@ -193,7 +195,7 @@ const editTodoItem = (identifier) => {
     } = originTodoItem.values
 
     const originTodoElement = findDomElement(identifier)
-    const formId = replaceDomElement(
+    replaceDomElement(
         templateNames.todoItemEditForm,
         originTodoElement,
         (identifier, component) => {
@@ -252,5 +254,11 @@ const editTodoItem = (identifier) => {
                 })
         }
     )
-    const component = findDomElement(formId)
+}
+
+const renewTodoCount = (category) => {
+    const todoCount = findDomElement(category.identifier).querySelector(
+        `.${classNames.todoHeaderTodoCount}`
+    )
+    todoCount.textContent = category.values.todoList.length
 }

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -84,7 +84,6 @@ export const initTodo = () => {
                         }
                         currentCategory = category
                         // todoList의 몇 번째 index인지 식별
-                        // currentIndex = null
                         for (let [
                             idx,
                             todoItem,
@@ -121,6 +120,7 @@ export const initTodo = () => {
                         // )
                         if (!skeletonUpdateFlag) return
                         findDomElement(skeletonElementId)?.remove()
+
                         if (currentIndex < category.values.todoList.length) {
                             skeletonElementId = createDomElementAsSibling(
                                 templateNames.todoItemSkeleton,
@@ -163,6 +163,14 @@ export const initTodo = () => {
                     if (dragDepth > 0) return
                     console.log('dragleave', category.identifier)
                     // e.stopPropagation()
+                    findDomElement(identifier)
+                        .querySelector(`.${classNames.skeleton}`)
+                        .remove()
+                })
+                component.addEventListener('drop', (e) => {
+                    console.log('drop', category.identifier)
+                    currentCategory = null
+                    currentIndex = null
                     findDomElement(identifier)
                         .querySelector(`.${classNames.skeleton}`)
                         .remove()

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -55,10 +55,10 @@ export const initTodo = () => {
                     // 일부 요소의 링크 열기와 같은 기본 동작 취소
                     e.preventDefault()
                 })
-
                 let dragDepth = 0
                 component.addEventListener('dragenter', (e) => {
                     dragDepth++
+                    let skeletonUpdateFlag = false
                     // if (!e.target.contains(`.${classNames.todoItemBody}`))
                     //     return
                     const categoryList = getState(TODO_CATEGORY_KEY)
@@ -68,41 +68,60 @@ export const initTodo = () => {
                             category.identifier
                         )
                         if (!parentElement.contains(e.target)) continue
+                        if (currentCategory !== category.identifier) {
+                            // 카테고리가 바뀌면 skeleton update
+                            console.log(
+                                'category change',
+                                currentCategory,
+                                'to',
+                                category.identifier
+                            )
+                            skeletonUpdateFlag = true
+                        }
                         currentCategory = category.identifier
                         // todoList의 몇 번째 index인지 식별
-                        currentIndex = null
+                        // currentIndex = null
                         for (let [
                             idx,
                             todoItem,
                         ] of category.values.todoList.entries()) {
                             if (todoItem.identifier === e.target.id) {
+                                if (currentIndex !== idx) {
+                                    // index가 바뀌면 skeleton update
+                                    console.log(
+                                        'index change',
+                                        currentIndex,
+                                        'to',
+                                        idx
+                                    )
+                                    skeletonUpdateFlag = true
+                                }
                                 currentIndex = idx
                                 break
                             }
                         }
+                        // 컨테이너 빈 영역에 대해서는 todo 리스트의 맨 끝에 추가
                         if (e.target.className === classNames.todoContainer) {
+                            skeletonUpdateFlag = true
                             currentIndex = category.values.todoList.length
                         }
                         // 자식 요소에 이벤트 전달되면 null값이 들어감...
                         if (currentIndex === null) {
                             return
                         }
-                        console.log('dragenter', currentCategory, currentIndex)
+                        // console.log('dragenter', currentCategory, currentIndex))
+                        console.log('flag', skeletonUpdateFlag)
                     }
                 })
-                component.addEventListener(
-                    'dragleave',
-                    (e) => {
-                        dragDepth--
-                        if (dragDepth > 0) return
-                        // console.log('dragleave', category.identifier)
-                        // e.stopPropagation()
-                        findDomElement(identifier)
-                            .querySelector(`.${classNames.skeleton}`)
-                            .remove()
-                    },
-                    true
-                )
+                component.addEventListener('dragleave', (e) => {
+                    dragDepth--
+                    if (dragDepth > 0) return
+                    console.log('dragleave', category.identifier)
+                    // e.stopPropagation()
+                    findDomElement(identifier)
+                        .querySelector(`.${classNames.skeleton}`)
+                        .remove()
+                })
             }
         )
         category.identifier = categoryId

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -45,6 +45,8 @@ export const initTodo = () => {
 
                 let currentCategory = null
                 let currentIndex = null
+                let skeletonElement = null
+
                 component.addEventListener('dragover', (e) => {
                     // 드롭을 허용하기 위해 기본 동작 취소
                     e.preventDefault()
@@ -55,12 +57,32 @@ export const initTodo = () => {
                 })
                 component.addEventListener('dragenter', (e) => {
                     const categoryList = getState(TODO_CATEGORY_KEY)
-                    categoryList.forEach((v, i) => {
-                        const parentElement = findDomElement(v.identifier)
-                        if (!parentElement.contains(e.target)) return
-                        currentCategory = v.identifier
-                        console.log('currentCategory', currentCategory)
-                    })
+                    for (let category of categoryList) {
+                        // 카테고리 식별
+                        const parentElement = findDomElement(
+                            category.identifier
+                        )
+                        if (!parentElement.contains(e.target)) continue
+                        currentCategory = category.identifier
+                        // todoList의 몇 번째 index인지 식별
+                        currentIndex = null
+                        for (let [
+                            idx,
+                            todoItem,
+                        ] of category.values.todoList.entries()) {
+                            if (todoItem.identifier === e.target.id) {
+                                currentIndex = idx
+                                console.log(
+                                    `currentCategory: ${currentCategory}, currentIndex: ${currentIndex}`
+                                )
+                                break
+                            }
+                        }
+
+                        if (currentIndex === null) {
+                            currentIndex = category.values.todoList.length
+                        }
+                    }
                 })
                 component.addEventListener('dragleave', (e) => {
                     // console.log('dragleave', e.target)

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -55,7 +55,10 @@ export const initTodo = () => {
                     // 일부 요소의 링크 열기와 같은 기본 동작 취소
                     e.preventDefault()
                 })
+
+                let dragDepth = 0
                 component.addEventListener('dragenter', (e) => {
+                    dragDepth++
                     // if (!e.target.contains(`.${classNames.todoItemBody}`))
                     //     return
                     const categoryList = getState(TODO_CATEGORY_KEY)
@@ -84,15 +87,15 @@ export const initTodo = () => {
                         if (currentIndex === null) {
                             return
                         }
-                        console.log('dragenter', currentCategory, currentIndex)
+                        // console.log('dragenter', currentCategory, currentIndex)
                     }
                 })
                 component.addEventListener(
                     'dragleave',
                     (e) => {
-                        // if (currentCategory === identifier) return
-                        // if (e.target.id !== identifier) return
-                        console.log('dragleave')
+                        dragDepth--
+                        if (dragDepth > 0) return
+                        console.log('dragleave', category.identifier)
                         e.stopPropagation()
                         findDomElement(identifier)
                             .querySelector(`.${classNames.skeleton}`)

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -87,7 +87,7 @@ export const initTodo = () => {
                         if (currentIndex === null) {
                             return
                         }
-                        // console.log('dragenter', currentCategory, currentIndex)
+                        console.log('dragenter', currentCategory, currentIndex)
                     }
                 })
                 component.addEventListener(
@@ -95,8 +95,8 @@ export const initTodo = () => {
                     (e) => {
                         dragDepth--
                         if (dragDepth > 0) return
-                        console.log('dragleave', category.identifier)
-                        e.stopPropagation()
+                        // console.log('dragleave', category.identifier)
+                        // e.stopPropagation()
                         findDomElement(identifier)
                             .querySelector(`.${classNames.skeleton}`)
                             .remove()

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -36,7 +36,7 @@ export const initTodo = () => {
 
         const element = findDomElement(categoryId)
         element.querySelector(`.${classNames.todoHeaderTitle}`).textContent =
-            category.values.category
+            category.values.categoryName
         element
             .querySelector(`.${classNames.addButton}`)
             .addEventListener('click', () => {
@@ -83,7 +83,6 @@ const enableAddTodoForm = (category) => {
         false
     )
     category.todoFormDomId = formId
-    // setState(TODO_FORM_DOM_ID_KEY, formId)
     const formElement = findDomElement(formId)
     formElement
         .querySelector(`.${classNames.todoAddFormSubmitBtn}`)
@@ -96,21 +95,20 @@ const enableAddTodoForm = (category) => {
             ).value
             const author = 'web'
             addTodoItem(title, content, author, category)
+            category.todoFormDomId = null
             removeDomElement(formId)
-            // setState(TODO_FORM_DOM_ID_KEY, null)
         })
     formElement
         .querySelector(`.${classNames.todoAddFormCancelBtn}`)
         .addEventListener('click', () => {
+            category.todoFormDomId = null
             removeDomElement(formId)
-            // setState(TODO_FORM_DOM_ID_KEY, null)
         })
 }
 
 const disableAddTodoForm = (category) => {
     removeDomElement(category.todoFormDomId)
     category.todoFormDomId = null
-    // setState(TODO_FORM_DOM_ID_KEY, null)
 }
 
 const initTodoItemElement = (todoElement, todoItem) => {

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -185,7 +185,7 @@ const manageDrag = (element) => {
 
 const addTodoItem = (title, content, author, category) => {
     const parentDomElement = findDomElement(category.identifier).querySelector(
-        classNames.todoBody
+        `.${classNames.todoBody}`
     )
     createDomElementAsChild(
         templateNames.todoItem,

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -25,12 +25,15 @@ export const initTodo = () => {
     // categoryList = [Category(-1, '해야할 일'), Category(-1, '하고 있는 일')]
     // storeData(TODO_CATEGORY_KEY, categoryList)
 
-    const todoHeaderParentElement = document.querySelector('.main')
+    const mainElement = document.querySelector('.main')
     categoryList.map((category) => {
         const categoryId = createDomElementAsChild(
             templateNames.todoHeader,
-            todoHeaderParentElement,
+            mainElement,
             (identifier, component) => {
+                component = component.querySelector(
+                    `.${classNames.todoContainer}`
+                )
                 component.querySelector(
                     `.${classNames.todoHeaderTitle}`
                 ).textContent = category.values.categoryName
@@ -39,6 +42,29 @@ export const initTodo = () => {
                     .addEventListener('click', () => {
                         onAddTodoButtonClick(category)
                     })
+
+                let currentCategory = null
+                let currentIndex = null
+                component.addEventListener('dragover', (e) => {
+                    // 드롭을 허용하기 위해 기본 동작 취소
+                    e.preventDefault()
+                })
+                component.addEventListener('drop', (e) => {
+                    // 일부 요소의 링크 열기와 같은 기본 동작 취소
+                    e.preventDefault()
+                })
+                component.addEventListener('dragenter', (e) => {
+                    const categoryList = getState(TODO_CATEGORY_KEY)
+                    categoryList.forEach((v, i) => {
+                        const parentElement = findDomElement(v.identifier)
+                        if (!parentElement.contains(e.target)) return
+                        currentCategory = v.identifier
+                        console.log('currentCategory', currentCategory)
+                    })
+                })
+                component.addEventListener('dragleave', (e) => {
+                    // console.log('dragleave', e.target)
+                })
             }
         )
         category.identifier = categoryId
@@ -151,38 +177,15 @@ const manageDrag = (element) => {
         // console.log(e.target)
         // console.log(element.offsetHeight)
     })
-    element.addEventListener('drag', (e) => {})
-    element.addEventListener('dragover', (e) => {
-        // 드롭을 허용하기 위해 기본 동작 취소
-        // e.preventDefault()
+    element.addEventListener('drag', (e) => {
+        // console.log('drag', e.target)
     })
     element.addEventListener('dragend', (e) => {})
-    element.addEventListener('dragenter', (e) => {
-        // console.log('dragenter', e.target)
-        const categoryList = getState(TODO_CATEGORY_KEY)
-        categoryList.forEach((v, i) => {
-            const parentElement = findDomElement(v.identifier)
-            if (!parentElement.contains(e.target)) return
-            currentIndex = v.identifier
-            console.log('currentIndex', currentIndex)
-            // if (v.identifier === parentElement.id) {
-            //     currentIndex = i
-            // }
-        })
-    })
-    element.addEventListener('dragleave', (e) => {
-        // console.log('dragleave', e.target)
-    })
-    element.addEventListener('drop', (e) => {
-        // 일부 요소의 링크 열기와 같은 기본 동작 취소
-        e.preventDefault()
-    })
 }
 
 const addTodoItem = (title, content, author, category) => {
-    // TODO: 하드코딩된 부모 클래스명 변경
     const parentDomElement = findDomElement(category.identifier).querySelector(
-        '.todos__body'
+        classNames.todoBody
     )
     createDomElementAsChild(
         templateNames.todoItem,

--- a/scripts/components/todo.js
+++ b/scripts/components/todo.js
@@ -8,6 +8,7 @@ import {
 } from '../utils/domUtil.js'
 import { getState, setState } from '../utils/stateUtil.js'
 import { loadData, storeData } from '../utils/storageUtil.js'
+import { Category } from '../domain/category.js'
 
 // const TODO_LIST_STORAGE_KEY = 'todoList'
 const TODO_CATEGORY_KEY = 'todoCategory'
@@ -139,6 +140,43 @@ const initTodoItemElement = (todoElement, todoItem) => {
         .addEventListener('click', () => {
             editTodoItem(identifier)
         })
+    manageDrag(todoElement.querySelector(`.${classNames.todoItemBody}`))
+}
+
+const manageDrag = (element) => {
+    // let isDragging = false
+    let currentCategory = null
+    let currentIndex = null
+    element.addEventListener('dragstart', (e) => {
+        // console.log(e.target)
+        // console.log(element.offsetHeight)
+    })
+    element.addEventListener('drag', (e) => {})
+    element.addEventListener('dragover', (e) => {
+        // 드롭을 허용하기 위해 기본 동작 취소
+        // e.preventDefault()
+    })
+    element.addEventListener('dragend', (e) => {})
+    element.addEventListener('dragenter', (e) => {
+        // console.log('dragenter', e.target)
+        const categoryList = getState(TODO_CATEGORY_KEY)
+        categoryList.forEach((v, i) => {
+            const parentElement = findDomElement(v.identifier)
+            if (!parentElement.contains(e.target)) return
+            currentIndex = v.identifier
+            console.log('currentIndex', currentIndex)
+            // if (v.identifier === parentElement.id) {
+            //     currentIndex = i
+            // }
+        })
+    })
+    element.addEventListener('dragleave', (e) => {
+        // console.log('dragleave', e.target)
+    })
+    element.addEventListener('drop', (e) => {
+        // 일부 요소의 링크 열기와 같은 기본 동작 취소
+        e.preventDefault()
+    })
 }
 
 const addTodoItem = (title, content, author, category) => {
@@ -157,7 +195,6 @@ const addTodoItem = (title, content, author, category) => {
         false
     )
 
-    // setState(TODO_CATEGORY_KEY, category)
     // category 객체를 참조하므로 setState를 안 해도 변경이 되긴 함 .. 맘에 안들지만 일단은 이렇게
     storeData(TODO_CATEGORY_KEY, getState(TODO_CATEGORY_KEY))
     renewTodoCount(category)

--- a/scripts/domain/Category.js
+++ b/scripts/domain/Category.js
@@ -1,0 +1,17 @@
+const createCategory = (
+    identifier,
+    categoryName,
+    todoList = [],
+    todoFormDomId = null
+) => {
+    return {
+        identifier: identifier,
+        todoFormDomId: todoFormDomId,
+        values: {
+            category: categoryName,
+            todoList: todoList,
+        },
+    }
+}
+
+export const Category = createCategory

--- a/scripts/domain/Category.js
+++ b/scripts/domain/Category.js
@@ -8,7 +8,7 @@ const createCategory = (
         identifier: identifier,
         todoFormDomId: todoFormDomId,
         values: {
-            category: categoryName,
+            categoryName: categoryName,
             todoList: todoList,
         },
     }

--- a/scripts/domain/TodoItem.js
+++ b/scripts/domain/TodoItem.js
@@ -2,7 +2,6 @@ const createTodoItem = (identifier, title, content, author) => {
     return {
         identifier: identifier,
         values: {
-            // category: category,
             title: title,
             content: content,
             author: author,

--- a/scripts/domain/TodoItem.js
+++ b/scripts/domain/TodoItem.js
@@ -1,3 +1,5 @@
+// TODO: indexing
+
 const createTodoItem = (identifier, title, content, author) => {
     return {
         identifier: identifier,

--- a/scripts/strings.js
+++ b/scripts/strings.js
@@ -33,6 +33,6 @@ export const templateNames = {
     todoHeader: 'todo-header-template',
     todoItem: 'todo-item-template',
     todoCategory: 'todo-category-template',
-    todoItemAddForm: 'todo-item-form-template',
-    todoItemEditForm: 'todo-item-form-template',
+    todoItemAddForm: 'todo-item-add-form-template',
+    todoItemEditForm: 'todo-item-edit-form-template',
 }

--- a/scripts/strings.js
+++ b/scripts/strings.js
@@ -28,6 +28,8 @@ export const classNames = {
     addButton: 'add-btn',
     deleteButton: 'delete-btn',
     editButton: 'edit-btn',
+
+    skeleton: 'skeleton',
 }
 
 export const templateNames = {

--- a/scripts/strings.js
+++ b/scripts/strings.js
@@ -5,6 +5,7 @@ export const classNames = {
     todoHeaderTodoCount: 'todos__header__todo-count',
     todoBody: 'todos__body',
 
+    todoItemBody: 'todos__body__item',
     todoItemTitle: 'todos__body__item__title',
     todoItemContent: 'todos__body__item__content',
     todoItemAuthor: 'todos__body__item__author',
@@ -32,6 +33,7 @@ export const classNames = {
 export const templateNames = {
     todoHeader: 'todo-header-template',
     todoItem: 'todo-item-template',
+    todoItemSkeleton: 'todo-item-skeleton',
     todoCategory: 'todo-category-template',
     todoItemAddForm: 'todo-item-add-form-template',
     todoItemEditForm: 'todo-item-edit-form-template',

--- a/scripts/strings.js
+++ b/scripts/strings.js
@@ -1,7 +1,9 @@
 export const classNames = {
+    todoContainer: 'todos',
     todoHeader: 'todos__header',
     todoHeaderTitle: 'todos__header__title',
     todoHeaderTodoCount: 'todos__header__todo-count',
+    todoBody: 'todos__body',
 
     todoItemTitle: 'todos__body__item__title',
     todoItemContent: 'todos__body__item__content',

--- a/scripts/utils/domUtil.js
+++ b/scripts/utils/domUtil.js
@@ -33,6 +33,24 @@ export const replaceDomElement = (templateId, originDomElement, initialize) => {
     return identifier
 }
 
+export const createDomElementAsSibling = (
+    templateId,
+    targetDomElement,
+    initialize,
+    insertAfter = true
+) => {
+    if (!initialize) throw new Error(`initialize is ${initialize}`)
+
+    const { identifier, component } = createDomElement(templateId)
+    initialize(identifier, component)
+    if (insertAfter) {
+        targetDomElement.after(component)
+    } else {
+        targetDomElement.before(component)
+    }
+    return identifier
+}
+
 export const createDomElement = (templateId) => {
     const templateElement = document.getElementById(templateId)
     const component = document.importNode(templateElement.content, true)

--- a/scripts/utils/domUtil.js
+++ b/scripts/utils/domUtil.js
@@ -1,6 +1,8 @@
 // import { storeData, loadData } from './storageUtil.js'
 import { setState, getState } from './stateUtil.js'
 
+// dom 최적화와 반대되는 방향...
+// async나 callback을 이용해서 dom 조작 작업이 완료된 뒤 DOM에 추가하는 방향으로 구현 수정?
 export const createDomElementAsChild = (
     templateId,
     parentDomElement,

--- a/scripts/utils/domUtil.js
+++ b/scripts/utils/domUtil.js
@@ -3,14 +3,19 @@ import { setState, getState } from './stateUtil.js'
 
 // dom 최적화와 반대되는 방향...
 // async나 callback을 이용해서 dom 조작 작업이 완료된 뒤 DOM에 추가하는 방향으로 구현 수정?
+
+// initialize = (documentFragment) => void
 export const createDomElementAsChild = (
     templateId,
     parentDomElement,
+    initialize,
     appendRear = true
 ) => {
     if (!parentDomElement) throw new Error(`Parent is ${parentDomElement}`)
+    if (!initialize) throw new Error(`initialize is ${initialize}`)
 
     const { identifier, component } = createDomElement(templateId)
+    initialize(identifier, component)
     if (appendRear) {
         parentDomElement.appendChild(component)
     } else {
@@ -19,8 +24,11 @@ export const createDomElementAsChild = (
     return identifier
 }
 
-export const replaceDomElement = (templateId, originDomElement) => {
+export const replaceDomElement = (templateId, originDomElement, initialize) => {
+    if (!initialize) throw new Error(`initialize is ${initialize}`)
+
     const { identifier, component } = createDomElement(templateId)
+    initialize(identifier, component)
     originDomElement.replaceWith(component)
     return identifier
 }

--- a/scripts/utils/stateUtil.js
+++ b/scripts/utils/stateUtil.js
@@ -1,3 +1,5 @@
+// map 으로 구현 변경하여 성능 최적화?
+
 const states = {}
 
 export const setState = (key, value) => {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -103,6 +103,7 @@ body {
 .todos {
     width: 320px;
     margin: 0px 8px;
+    padding: 0px 0px 200px 0px;
     min-height: 500px;
     border-style: solid;
     border-width: 1px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -232,6 +232,11 @@ body {
     font: var(--font-medium-r);
 }
 
+.skeleton {
+    margin: 0px;
+    padding: 0px;
+}
+
 .btn {
     width: 24px;
     height: 24px;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,7 +1,8 @@
-.body {
+html,
+body {
     width: 100%;
-    background-color: var(--color-bg);
     height: 100%;
+    background-color: var(--color-bg);
 }
 
 .header {
@@ -102,6 +103,10 @@
 .todos {
     width: 320px;
     margin: 0px 8px;
+    min-height: 500px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: black;
 }
 
 .todos__header {
@@ -137,7 +142,7 @@
 
 .todos__body {
     list-style-type: none;
-    width: 100%;
+    /* min-height: 300px; */
 }
 .todos__body__item {
     display: flex;


### PR DESCRIPTION
## 주요 작업
- drag & drop 기능 구현
    - dragenter, dragleave 이벤트를 통해 드래그 중인 위치가 어느 카테고리의 몇 번째 index인지 탐색함
    - 이후 그 자리에 잔상(skeleton)을 생성함

## 학습 키워드
- JavaScript Drag & Drop API
- 이벤트 흐름: Event Capturing, Bubbling

## 고민과 해결과정
- DocumentFragment는 가상의 DOM 객체로서, 실제 DOM 객체와 달리 접근하지 못하는 props가 존재한다 (ex: offsetHeight). 이 사실을 모른 채 DocumentFragment 를 사용했었는데, 그 과정에서 특정 prop이 undefined로 반환되어 문제를 찾는 데 시간을 많이 썼다.
- dragenter 및 dragleave 이벤트를 등록한 부모 객체의 모든 자식 노드들에 대해 이벤트가 발생해서, 원하는 노드에 대해서만 이벤트를 처리하도록 예외처리 하는 데 시간이 많이 들었다.
- 부모 객체에서 자식 객체로 드래그할 때도 dragleave 이벤트가 호출되었다. 이를 막기 위한 방법을 적용했는데, dragenter 시 depth++ 해주고 dragleave 시에는 depth-- 해 준다. depth가 0일 때에 발생한 dragleave 이벤트만 유효 처리하는 방식으로 해결하였다.