### PR TITLE
[박규한] - 카드 이동 기능 개선 & TODO 옵저버 패턴 적용(add, remove)

### DIFF
--- a/components/ColumnItem/ColumnItem.js
+++ b/components/ColumnItem/ColumnItem.js
@@ -1,3 +1,4 @@
+import todoStore from "../../store/TodoStore.js";
 import loadStyleSheet from "../../utils/loadStyleSheet.js";
 import createColumnItem from "./ui/createColumnItem.js";
 
@@ -12,6 +13,29 @@ const ColumnItem = ({ id, title = "", content = "", author = "web" }) => {
   });
 
   return $columnItem;
+};
+
+todoStore.subscribe(({ sectionId, newTodo, todoList }) => {
+  const $columnBody = document.querySelector(`#${sectionId} .column__body`);
+
+  $columnBody.replaceChild(ColumnItem({ ...newTodo }), $columnBody.firstChild);
+
+  updateCount({
+    $columnBody,
+    newTodoList: todoList,
+    sectionId,
+  });
+});
+
+const updateCount = ({ $columnBody, newTodoList, sectionId }) => {
+  const itemLength = newTodoList.find((section) => section.id === sectionId)
+    .items.length;
+
+  const $columnCount = $columnBody
+    .closest(".column__container")
+    .querySelector(".column__count");
+
+  $columnCount.textContent = itemLength;
 };
 
 export default ColumnItem;

--- a/components/ColumnItem/ColumnItem.js
+++ b/components/ColumnItem/ColumnItem.js
@@ -15,10 +15,21 @@ const ColumnItem = ({ id, title = "", content = "", author = "web" }) => {
   return $columnItem;
 };
 
-todoStore.subscribe(({ sectionId, newTodo, todoList }) => {
+todoStore.subscribe((action, { sectionId, newTodo, deletedId, todoList }) => {
   const $columnBody = document.querySelector(`#${sectionId} .column__body`);
 
-  $columnBody.replaceChild(ColumnItem({ ...newTodo }), $columnBody.firstChild);
+  if (action === "add") {
+    $columnBody.replaceChild(
+      ColumnItem({ ...newTodo }),
+      $columnBody.firstChild
+    );
+  } else if (action === "remove") {
+    const $columnItem = document.querySelector(
+      `.column__item[data-id="${deletedId}"]`
+    );
+
+    $columnItem.remove();
+  }
 
   updateCount({
     $columnBody,

--- a/components/ColumnItem/ui/createItemButtonContainer.js
+++ b/components/ColumnItem/ui/createItemButtonContainer.js
@@ -13,6 +13,7 @@ const createItemButtonContainer = () => {
 
   const $deleteButton = createButton({
     className: "delete__button",
+    type: "card",
   });
 
   const $deleteImg = createDeleteSvg({

--- a/components/ColumnSection/ColumnBody/ColumnBody.js
+++ b/components/ColumnSection/ColumnBody/ColumnBody.js
@@ -10,57 +10,39 @@ import createColumnBody from "./ui/createColumnBody.js";
 loadStyleSheet("/components/ColumnSection/ColumnBody/styles.css");
 
 const ColumnBody = ({ sectionId, items }) => {
-  let shadowElement = null;
-
   const handleDragOver = (e) => {
     e.preventDefault();
+    const $draggedElement = document.querySelector(".dragging");
+
+    // 드래그가 이동한 좌표에서 가장 가까운 columnItem
     const $target = e.target.closest(".column__item");
 
-    if (!shadowElement) {
-      shadowElement = document.createElement("div");
-      shadowElement.classList.add("after-image", "shadow-normal");
-    }
-
-    if ($target) {
+    if ($draggedElement && $target) {
+      // offset: target의 DOM 요소를 가져와서, 마우스 y좌표와 요소의 상단부분의 차이
+      // 차이가 target의 height의 절반보다 작으면 위로, 크면 아래로 이동
       const rect = $target.getBoundingClientRect();
       const offset = e.clientY - rect.top;
 
       if (offset < rect.height / 2) {
-        $columnBody.insertBefore(shadowElement, $target);
+        $columnBody.insertBefore($draggedElement, $target);
       } else {
-        $columnBody.insertBefore(shadowElement, $target.nextSibling);
+        $columnBody.insertBefore($draggedElement, $target.nextSibling);
       }
-    } else {
-      $columnBody.appendChild(shadowElement);
     }
   };
 
   const handleDrop = (e) => {
     e.preventDefault();
     const prevSectionId = e.dataTransfer.getData("text/prevSectionId");
-    const draggedElement = document.querySelector(".dragging");
-
-    if (shadowElement && draggedElement) {
-      $columnBody.replaceChild(draggedElement, shadowElement);
-      shadowElement.remove();
-      shadowElement = null;
-    }
+    const $draggedElement = document.querySelector(".dragging");
 
     const sectionId = $columnBody.closest(".column__container").id;
-    const itemId = Number(draggedElement.dataset.id);
-    const title = draggedElement.querySelector(
+    const itemId = Number($draggedElement.dataset.id);
+    const title = $draggedElement.querySelector(
       ".column__item__title"
     ).textContent;
 
     updateTodoList({ sectionId, itemId, prevSectionId, title });
-  };
-
-  const handleDragLeave = (e) => {
-    // 칼럼 벗어남 & 잔상 존재
-    if (!e.currentTarget.contains(e.relatedTarget) && shadowElement) {
-      shadowElement.remove();
-      shadowElement = null;
-    }
   };
 
   const $columnBody = createColumnBody({
@@ -70,7 +52,6 @@ const ColumnBody = ({ sectionId, items }) => {
 
   $columnBody.addEventListener("dragover", handleDragOver);
   $columnBody.addEventListener("drop", handleDrop);
-  $columnBody.addEventListener("dragleave", handleDragLeave);
 
   return $columnBody;
 };

--- a/components/ColumnSection/ColumnBody/ColumnBody.js
+++ b/components/ColumnSection/ColumnBody/ColumnBody.js
@@ -1,116 +1,15 @@
-import { STORAGE_KEY } from "../../../constants/storageKey.js";
-import historyStore from "../../../store/historyStore.js";
 import loadStyleSheet from "../../../utils/loadStyleSheet.js";
-import {
-  loadLocalStorage,
-  saveLocalStorage,
-} from "../../../utils/localStorage.js";
 import createColumnBody from "./ui/createColumnBody.js";
 
 loadStyleSheet("/components/ColumnSection/ColumnBody/styles.css");
 
 const ColumnBody = ({ sectionId, items }) => {
-  const handleDragOver = (e) => {
-    e.preventDefault();
-    const $draggedElement = document.querySelector(".dragging");
-
-    // 드래그가 이동한 좌표에서 가장 가까운 columnItem
-    const $target = e.target.closest(".column__item");
-
-    if ($draggedElement && $target) {
-      // offset: target의 DOM 요소를 가져와서, 마우스 y좌표와 요소의 상단부분의 차이
-      // 차이가 target의 height의 절반보다 작으면 위로, 크면 아래로 이동
-      const rect = $target.getBoundingClientRect();
-      const offset = e.clientY - rect.top;
-
-      if (offset < rect.height / 2) {
-        $columnBody.insertBefore($draggedElement, $target);
-      } else {
-        $columnBody.insertBefore($draggedElement, $target.nextSibling);
-      }
-    }
-  };
-
-  const handleDrop = (e) => {
-    e.preventDefault();
-    const prevSectionId = e.dataTransfer.getData("text/prevSectionId");
-    const $draggedElement = document.querySelector(".dragging");
-
-    const sectionId = $columnBody.closest(".column__container").id;
-    const itemId = Number($draggedElement.dataset.id);
-    const title = $draggedElement.querySelector(
-      ".column__item__title"
-    ).textContent;
-
-    updateTodoList({ sectionId, itemId, prevSectionId, title });
-  };
-
   const $columnBody = createColumnBody({
     sectionId,
     items,
   });
 
-  $columnBody.addEventListener("dragover", handleDragOver);
-  $columnBody.addEventListener("drop", handleDrop);
-
   return $columnBody;
-};
-
-// TODO: 배열 메서드로 개선 필요
-const updateTodoList = ({ sectionId, itemId, prevSectionId, title }) => {
-  const todoList = loadLocalStorage(STORAGE_KEY.todoList);
-
-  let draggedItem = null;
-
-  const prevColumn = todoList.find(
-    (section) => section.id === prevSectionId
-  ).title;
-  const nextColumn = todoList.find((section) => section.id === sectionId).title;
-
-  const filteredList = todoList.map((section) => {
-    if (section.items.some((item) => item.id === itemId)) {
-      draggedItem = section.items.find((item) => item.id === itemId);
-      return {
-        ...section,
-        items: section.items.filter((item) => item.id !== itemId),
-      };
-    }
-    return section;
-  });
-
-  const finalList = filteredList.map((section) => {
-    if (section.id === sectionId && draggedItem) {
-      return {
-        ...section,
-        items: [...section.items, draggedItem],
-      };
-    }
-    return section;
-  });
-
-  updateCount(finalList);
-  saveLocalStorage(STORAGE_KEY.todoList, finalList);
-
-  if (prevColumn !== nextColumn) {
-    historyStore.action({
-      action: "move",
-      title,
-      prevColumn: prevColumn,
-      nextColumn: nextColumn,
-    });
-  }
-};
-
-const updateCount = (todoList) => {
-  const $columnSection = document.querySelector(".column__section");
-
-  todoList.forEach(({ id, items }) => {
-    const $count = $columnSection
-      .querySelector(`#${id}`)
-      .querySelector(".column__count");
-
-    $count.textContent = items.length;
-  });
 };
 
 export default ColumnBody;

--- a/components/Header/UserHistory/UserHistory.js
+++ b/components/Header/UserHistory/UserHistory.js
@@ -4,14 +4,13 @@ import createHistoryFooter from "../ui/createHistoryFooter.js";
 import HistoryHeader from "./HistoryHeader/HistoryHeader.js";
 import HistoryMain from "./HistoryMain/HistoryMain.js";
 
-const updateHistoryFooter = ({ handleDeleteHistory, histories }) => {
+const updateHistoryFooter = ({ histories }) => {
   const $userHistoryDOM = document.querySelector(".user-history");
   const $historyFooterDOM = $userHistoryDOM.querySelector(".history__footer");
 
   // 활동 기록 최초 생성
   if (histories.length > 0 && !$historyFooterDOM) {
     const $historyFooter = createHistoryFooter({
-      handleDeleteHistory,
       histories,
     });
 
@@ -23,17 +22,12 @@ const updateHistoryFooter = ({ handleDeleteHistory, histories }) => {
 };
 
 const UserHistory = () => {
-  const handleDeleteHistory = () => {
-    historyStore.clear();
-  };
-
   const $userHistory = createElement("div", {
     className: "user-history shadow-floating",
   });
   const $historyHeader = HistoryHeader();
   const $historyMain = HistoryMain({ histories: historyStore.histories });
   const $historyFooter = createHistoryFooter({
-    handleDeleteHistory,
     histories: historyStore.histories,
   });
 
@@ -46,7 +40,6 @@ const UserHistory = () => {
     $historyMainDOM.replaceWith($updatedHistoryMain);
 
     updateHistoryFooter({
-      handleDeleteHistory,
       histories: updatedHistories,
     });
   });

--- a/components/Header/ui/createHistoryFooter.js
+++ b/components/Header/ui/createHistoryFooter.js
@@ -1,7 +1,7 @@
 import { createButton, createElement } from "../../../dom.js";
 import createModal from "../../Modal/createModal.js";
 
-const createHistoryFooter = ({ handleDeleteHistory, histories }) => {
+const createHistoryFooter = ({ histories }) => {
   if (histories.length === 0) return "";
 
   const $historyFooter = createElement("div", {
@@ -9,14 +9,8 @@ const createHistoryFooter = ({ handleDeleteHistory, histories }) => {
   });
 
   const $deleteButton = createButton({
-    className: "display-bold14",
+    className: "delete__button display-bold14",
     text: "기록 전체 삭제",
-    handleClick: () => {
-      createModal({
-        content: "모든 사용자 활동 기록을 삭제할까요?",
-        onClick: handleDeleteHistory,
-      });
-    },
   });
 
   $historyFooter.appendChild($deleteButton);

--- a/components/Header/ui/createSortButton.js
+++ b/components/Header/ui/createSortButton.js
@@ -15,13 +15,9 @@ const getSortedTodoList = ({ todoList, sortType }) => {
   return [...todoList].map((section) => {
     section.items.sort((a, b) => {
       if (sortType === "최신 순") {
-        return (
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-        );
+        return new Date(b.createdAt) - new Date(a.createdAt);
       } else if (sortType === "생성 순") {
-        return (
-          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-        );
+        return new Date(a.createdAt) - new Date(b.createdAt);
       }
       return 0;
     });

--- a/components/Modal/createModal.js
+++ b/components/Modal/createModal.js
@@ -3,7 +3,7 @@ import loadStyleSheet from "../../utils/loadStyleSheet.js";
 
 loadStyleSheet("/components/Modal/styles.css");
 
-const createModal = ({ title = "", content = "" }) => {
+const createModal = ({ title = "", content = "", type = "card" }) => {
   const $modalContainer = document.getElementById("modal-container");
   const $modal = createElement("div", { id: "modal" });
 
@@ -18,7 +18,7 @@ const createModal = ({ title = "", content = "" }) => {
         }
         <div class="modal__buttonContainer">
         <button class="cancel__button display-bold14">취소</button>
-          <button class="delete__button display-bold14">삭제</button>
+          <button class="delete__button display-bold14" data-type=${type}>삭제</button>
         </div>
       </div>
     `;

--- a/handlers/columnBody.js
+++ b/handlers/columnBody.js
@@ -1,3 +1,6 @@
+import { STORAGE_KEY } from "../constants/storageKey.js";
+import { loadLocalStorage, saveLocalStorage } from "../utils/localStorage.js";
+
 export const handleDragStart = (e) => {
   const $columnItem = e.target.closest(".column__item");
   const prevSectionId = $columnItem.closest(".column__container").id;
@@ -8,4 +11,95 @@ export const handleDragStart = (e) => {
 export const handleDragEnd = (e) => {
   const $columnItem = e.target.closest(".column__item");
   $columnItem.classList.remove("dragging");
+};
+
+export const handleDragOver = (e) => {
+  e.preventDefault();
+
+  const $columnBody = e.target.closest(".column__body");
+  const $draggedElement = document.querySelector(".dragging");
+  const $target = e.target.closest(".column__item");
+
+  if ($columnBody && $draggedElement && $target) {
+    const rect = $target.getBoundingClientRect();
+    const offset = e.clientY - rect.top;
+
+    if (offset < rect.height / 2) {
+      $columnBody.insertBefore($draggedElement, $target);
+    } else {
+      $columnBody.insertBefore($draggedElement, $target.nextSibling);
+    }
+  }
+};
+
+export const handleDrop = (e) => {
+  e.preventDefault();
+  const prevSectionId = e.dataTransfer.getData("text/prevSectionId");
+
+  const $draggedElement = document.querySelector(".dragging");
+  const $columnBody = e.target.closest(".column__body");
+
+  const sectionId = $columnBody.closest(".column__container").id;
+  const itemId = Number($draggedElement.dataset.id);
+  const title = $draggedElement.querySelector(
+    ".column__item__title"
+  ).textContent;
+
+  updateTodoList({ sectionId, itemId, prevSectionId, title });
+};
+
+const updateTodoList = ({ sectionId, itemId, prevSectionId, title }) => {
+  const todoList = loadLocalStorage(STORAGE_KEY.todoList);
+
+  let draggedItem = null;
+
+  const prevColumn = todoList.find(
+    (section) => section.id === prevSectionId
+  ).title;
+  const nextColumn = todoList.find((section) => section.id === sectionId).title;
+
+  const filteredList = todoList.map((section) => {
+    if (section.items.some((item) => item.id === itemId)) {
+      draggedItem = section.items.find((item) => item.id === itemId);
+      return {
+        ...section,
+        items: section.items.filter((item) => item.id !== itemId),
+      };
+    }
+    return section;
+  });
+
+  const finalList = filteredList.map((section) => {
+    if (section.id === sectionId && draggedItem) {
+      return {
+        ...section,
+        items: [...section.items, draggedItem],
+      };
+    }
+    return section;
+  });
+
+  updateCount(finalList);
+  saveLocalStorage(STORAGE_KEY.todoList, finalList);
+
+  if (prevColumn !== nextColumn) {
+    historyStore.action({
+      action: "move",
+      title,
+      prevColumn: prevColumn,
+      nextColumn: nextColumn,
+    });
+  }
+};
+
+const updateCount = (todoList) => {
+  const $columnSection = document.querySelector(".column__section");
+
+  todoList.forEach(({ id, items }) => {
+    const $count = $columnSection
+      .querySelector(`#${id}`)
+      .querySelector(".column__count");
+
+    $count.textContent = items.length;
+  });
 };

--- a/handlers/columnItem.js
+++ b/handlers/columnItem.js
@@ -1,8 +1,7 @@
 import ColumnInputItem from "../components/ColumnInputItem/ColumnInputItem.js";
 import createModal from "../components/Modal/createModal.js";
-import { STORAGE_KEY } from "../constants/storageKey.js";
 import historyStore from "../store/historyStore.js";
-import { loadLocalStorage, saveLocalStorage } from "../utils/localStorage.js";
+import todoStore from "../store/TodoStore.js";
 
 export const handleClickDelete = (e) => {
   const $columnItem = e.target.closest(".column__item");
@@ -34,34 +33,15 @@ export const handleClickEdit = (e) => {
   $columnItem.replaceWith($columnInputItem);
 };
 
-export const deleteColumnItem = ({ sectionId, itemId, $columnItem }) => {
-  const todoList = loadLocalStorage(STORAGE_KEY.todoList);
-
-  const filteredList = todoList.map((section) =>
-    section.id === sectionId
-      ? {
-          ...section,
-          items: section.items.filter((item) => item.id !== itemId),
-        }
-      : section
-  );
-
-  const itemLength = filteredList.find((section) => section.id === sectionId)
-    .items.length;
-
-  const $columnCount = $columnItem
-    .closest(".column__container")
-    .querySelector(".column__count");
-
-  $columnCount.textContent = itemLength;
-  saveLocalStorage(STORAGE_KEY.todoList, filteredList);
-
-  $columnItem.remove();
-
-  const deletedCard = todoList
+export const deleteColumnItem = ({ sectionId, itemId }) => {
+  const deletedCard = todoStore.todoList
     .find((section) => section.id === sectionId)
     .items.find((item) => item.id === itemId);
 
+  todoStore.remove({
+    sectionId,
+    deletedId: deletedCard.id,
+  });
   historyStore.action({
     action: "remove",
     title: deletedCard.title,

--- a/handlers/index.js
+++ b/handlers/index.js
@@ -1,4 +1,9 @@
-import { handleDragEnd, handleDragStart } from "./columnBody.js";
+import {
+  handleDragEnd,
+  handleDragOver,
+  handleDragStart,
+  handleDrop,
+} from "./columnBody.js";
 import { handleCancelAdd, handleClickAdd } from "./columnHeader.js";
 import {
   handleCancelEdit,
@@ -66,6 +71,22 @@ export const addRootEventListener = () => {
 
     if ($column__body) {
       handleDragEnd(e);
+    }
+  });
+
+  $root.addEventListener("dragover", (e) => {
+    const $columnItem = e.target.closest(".column__item");
+
+    if ($columnItem) {
+      handleDragOver(e);
+    }
+  });
+
+  $root.addEventListener("drop", (e) => {
+    const $columnItem = e.target.closest(".column__item");
+
+    if ($columnItem) {
+      handleDrop(e);
     }
   });
 };

--- a/handlers/index.js
+++ b/handlers/index.js
@@ -8,6 +8,7 @@ import { handleCancelAdd, handleClickAdd } from "./columnHeader.js";
 import {
   handleCancelEdit,
   handleInputContent,
+  handleInputTitle,
   handleSubmit,
 } from "./columnInputItem.js";
 import { handleClickDelete, handleClickEdit } from "./columnItem.js";

--- a/handlers/index.js
+++ b/handlers/index.js
@@ -12,7 +12,8 @@ import {
   handleSubmit,
 } from "./columnInputItem.js";
 import { handleClickDelete, handleClickEdit } from "./columnItem.js";
-import { handleClose, handleDeleteModal } from "./modal.js";
+import { deleteHistory, handleClose, handleDeleteCard } from "./modal.js";
+import { handleClickDeleteHistory } from "./userHistory.js";
 
 const store = { isTodoAdding: false };
 
@@ -27,9 +28,14 @@ export const addRootEventListener = () => {
 
     const $closeButton = target.closest(".close__button");
     const $submitButton = target.closest(".submit__button");
+    const $deleteHistoryButton = target.closest(
+      ".history__footer .delete__button"
+    );
 
     if ($addButton) {
       handleClickAdd(e, store);
+    } else if ($deleteHistoryButton) {
+      handleClickDeleteHistory();
     } else if ($deleteButton) {
       handleClickDelete(e);
     } else if ($editButton) {
@@ -105,7 +111,8 @@ export const addModalEventListener = () => {
     if ($dimmed || $cancelButton) {
       handleClose(e);
     } else if ($deleteButton) {
-      handleDeleteModal(e);
+      const type = $deleteButton.dataset.type;
+      type === "card" ? handleDeleteCard(e) : deleteHistory(e);
     }
   });
 };

--- a/handlers/modal.js
+++ b/handlers/modal.js
@@ -15,7 +15,7 @@ export const handleDeleteCard = (e) => {
     `.column__item[data-id="${itemId}"]`
   );
   const sectionId = $columnItem.closest(".column__container").id;
-  deleteColumnItem({ sectionId, itemId, $columnItem });
+  deleteColumnItem({ sectionId, itemId });
   handleClose(e);
 };
 

--- a/handlers/modal.js
+++ b/handlers/modal.js
@@ -1,3 +1,4 @@
+import historyStore from "../store/historyStore.js";
 import { deleteColumnItem } from "./columnItem.js";
 
 export const handleClose = (e) => {
@@ -8,12 +9,17 @@ export const handleClose = (e) => {
   }
 };
 
-export const handleDeleteModal = (e) => {
+export const handleDeleteCard = (e) => {
   const itemId = Number(e.target.closest("#modal-container").dataset.itemId);
   const $columnItem = document.querySelector(
     `.column__item[data-id="${itemId}"]`
   );
   const sectionId = $columnItem.closest(".column__container").id;
   deleteColumnItem({ sectionId, itemId, $columnItem });
+  handleClose(e);
+};
+
+export const deleteHistory = (e) => {
+  historyStore.clear();
   handleClose(e);
 };

--- a/handlers/userHistory.js
+++ b/handlers/userHistory.js
@@ -1,0 +1,8 @@
+import createModal from "../components/Modal/createModal.js";
+
+export const handleClickDeleteHistory = () => {
+  createModal({
+    content: "모든 사용자 활동 기록을 삭제할까요?",
+    type: "history",
+  });
+};

--- a/store/Observable.js
+++ b/store/Observable.js
@@ -11,8 +11,8 @@ class Observable {
     this._observers.delete(observer);
   }
 
-  notify(data) {
-    this._observers.forEach((observer) => observer(data));
+  notify(action, data) {
+    this._observers.forEach((observer) => observer(action, data));
   }
 }
 

--- a/store/TodoStore.js
+++ b/store/TodoStore.js
@@ -22,7 +22,21 @@ class TodoStore extends Observable {
         ? { ...section, items: [...section.items, newTodo] }
         : section
     );
-    this.notify({ sectionId, newTodo, todoList: this.#todoList });
+    this.notify("add", { sectionId, newTodo, todoList: this.#todoList });
+    saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
+  }
+
+  remove({ sectionId, deletedId }) {
+    this.#todoList = [...this.#todoList].map((section) =>
+      section.id === sectionId
+        ? {
+            ...section,
+            items: section.items.filter((item) => item.id !== deletedId),
+          }
+        : section
+    );
+
+    this.notify("remove", { sectionId, deletedId, todoList: this.#todoList });
     saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
   }
 

--- a/store/TodoStore.js
+++ b/store/TodoStore.js
@@ -1,0 +1,46 @@
+import { STORAGE_KEY } from "../constants/storageKey.js";
+import {
+  clearLocalStorage,
+  loadLocalStorage,
+  saveLocalStorage,
+} from "../utils/localStorage.js";
+import { getRandomId } from "../utils/random.js";
+import Observable from "./Observable.js";
+
+class TodoStore extends Observable {
+  #todoList = loadLocalStorage(STORAGE_KEY.todoList) || [];
+
+  add({ sectionId, todo }) {
+    const newTodo = {
+      ...todo,
+      id: getRandomId(),
+      createdAt: new Date(),
+    };
+
+    this.#todoList = [...this.#todoList].map((section) =>
+      section.id === sectionId
+        ? { ...section, items: [...section.items, newTodo] }
+        : section
+    );
+    this.notify({ sectionId, newTodo, todoList: this.#todoList });
+    saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
+  }
+
+  clear() {
+    this.#todoList = [];
+    this.notify(this.#todoList);
+    clearLocalStorage(STORAGE_KEY.todoList);
+  }
+
+  get todoList() {
+    return this.#todoList;
+  }
+
+  set todoList(data) {
+    this.#todoList = data;
+  }
+}
+
+const todoStore = new TodoStore();
+
+export default todoStore;


### PR DESCRIPTION

## 주요 작업

- TODO 옵저버 패턴 적용 (add, remove)
- drag & drop 기능 개선
  - 기존에는 가짜로 element를 만들어 잔상을 만들어냈는데, 카드 자체를 이동시키도록 구현하였습니다. 또한 drag & drop이 동작하는 방식에 대해 잘 이해를 못했는데 이해 완료하였습니다.
1. 마우스를 드래그로 이동하여 발생한 드래그 이벤트에서 가장 가까운 columnItem
    
    ```tsx
    const $target = e.target.closest(".column__item");
    ```
    
2. 드래그 중인 요소 찾기 (이미 drag 시작할 때 .dragging 클래스 추가)
    
    ```tsx
    const $draggedElement = document.querySelector(".dragging");
    ```
    
3. 드래그 중인 요소가 있고, 드래그 중인 마우스 포인터가 columnItem근처에 있다면 어디에 삽입할 지 계산한다.
    
    ```tsx
    const rect = $target.getBoundingClientRect();
    const offset = e.clientY - rect.top;
    ```
    
4. columnItem이 화면 상단으로부터 떨어진 거리와 마우스 포인터가 화면 상단으로부터 떨어진 거리의 차이를 계산해서 columnItem 위에 넣을지, 아래 넣을지 결정한다.
    
    ```tsx
    if (offset < rect.height / 2) {
    	$columnBody.insertBefore($draggedElement, $target);
    	} else {
    	$columnBody.insertBefore($draggedElement, $target.nextSibling);
    }
    ```

## 학습 키워드

- 옵저버 패턴: UI 작업과 데이터 처리를 분리한다. 관심사를 분리한다.

## 고민과 해결과정

- TODO에도 옵저버 패턴 적용
  - addEventListener과 비슷하다는 생각에 subscribe를 여러개하면 안된다고 생각하게 되서 하나의 subscribe 안에 action에 따라 분기처리하게 구현했었습니다. 하지만 지금 다시 보니 subscribe는 Set에 add만 해주고, notify할 때 모든 함수를 도니까 분리해도 될 것 같긴 합니다. 근데 결국 action을 분기처리 해야되긴 할 것 같아요!
