### PR TITLE
[se-jun] 칼럼명 변경, 칼럼 추가/삭제, 카드 자유롭게 이동 기능 완료

### DIFF
--- a/css/card.css
+++ b/css/card.css
@@ -4,7 +4,7 @@
     list-style: none;
     padding-left: 0;
     width: 100%;
-    height: calc(100vh - 210px);
+    height: calc(100vh - 205px);
 }
 
 .card-list li {

--- a/css/style.css
+++ b/css/style.css
@@ -1,8 +1,13 @@
+html {
+    margin-bottom: 0;
+    height: 100%;
+}
 body {
     background-color:#F7F7FC;
     margin-top: 50px;
     margin-left: 5%;
     margin-right: 5%;
+    margin-bottom: 0;
 }
 
 .no-select {
@@ -25,6 +30,25 @@ header h1 {
     align-items: center;
 }
 
+main {
+    position: relative;
+}
+
+main::after {
+    display: block;
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 30px;
+    height: 100%;
+    background: linear-gradient(to left, rgba(0, 0, 0, 0.1), transparent);
+}
+
+.hidden::after{
+    display: none;
+}
+
 .chip {
     display: flex;
     height: 21px;
@@ -34,9 +58,10 @@ header h1 {
     align-items: center;
     padding: 2px 8px;
     margin-left: 16px;
+    cursor: pointer;
 }
 
-.chip #sort-icon {
+#sort-icon {
     margin-left: 2px;
 }
 
@@ -64,18 +89,22 @@ ul {
 
 
 #column-area {
+    position: relative;
     list-style: none;
     display: flex;
     width: 100%;
     height: 100%;
+    overflow-x: auto;
+    margin-bottom: 0;
 }
 
 
 .column-id {
     width: 30%;
-    min-width: 120px;
+    min-width: 280px;
     max-width: 320px;
     margin-right: 24px;
+    height: 100%;
 }
 
 .column-header {
@@ -120,6 +149,23 @@ ul {
     margin-left: 10px;
     padding: 5px 5px 2px 5px;
     border-radius: 5px;
+}
+
+.fab {
+    position: fixed;
+    bottom: 50px;
+    right: 50px;
+    width: 56px;
+    height: 56px;
+    background-color: #007AFF;
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.3s ease;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -12,18 +12,6 @@
 </head>
 <body>
 
-    <!-- 다이얼로그 -->
-    <div id="history-dialog" class="history-dialog">
-        <div class="history-dialog-header">
-            <div class="history-dialog-title">사용자 활동 기록</div>
-            <button class="icon-button close-history">
-                <span class="material-icons">
-                close
-                </span>
-                <div>닫기</div>
-            </button>
-        </div>
-    </div>
         
     <header>
         <div class="header-left">
@@ -42,6 +30,19 @@
         <ul id="column-area">
         </ul>
     </main>
+    
+    <!-- 모달 -->
+    <div id="history-dialog" class="history-dialog">
+        <div class="history-dialog-header">
+            <div class="history-dialog-title">사용자 활동 기록</div>
+            <button class="icon-button close-history">
+                <span class="material-icons">
+                close
+                </span>
+                <div>닫기</div>
+            </button>
+        </div>
+    </div>
 
     <div class="fab">
         <i class="material-icons">add</i>
@@ -52,6 +53,7 @@
     
 
     <script type="module" src="./js/main.js"></script>
+    <script type="module" src="./js/event_listeners.js"></script>
     <script src="./js/history.js"></script>
     <script type="module" src="./js/alert.js"></script>
 

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <header>
         <div class="header-left">
             <h1>TASKIFY</h1>
-            <div class="chip no-select">
+            <div class="chip">
                 <object id="sort-icon" data="./assets/icons/sort_icon.svg" type="image/svg+xml" width="12" height="12"></object>
                 <div>생성 순</div>
             </div>
@@ -43,9 +43,13 @@
         </ul>
     </main>
 
+    <div class="fab">
+        <i class="material-icons">add</i>
+    </div>
 
     <div class="overlay" id="overlay"></div>
     <div id="alert-area"></div>
+    
 
     <script type="module" src="./js/main.js"></script>
     <script src="./js/history.js"></script>

--- a/js/alert.js
+++ b/js/alert.js
@@ -1,18 +1,30 @@
 export let overlay = document.getElementById('overlay');
+
 const alertArea = document.getElementById('alert-area');
 
+function deleteHTML(action) {
+    return `
+    <p class="delObj"></p>
+    <button id="cancel-${action}-button" class="modal-cancel-button">취소</button>
+    <button id="confirm-${action}-button" class="modal-confirm-button">확인</button>`
+};
 
 // 특정 카드 삭제
 export function createDeleteCardAlert(cardId) {
     const delCardAlertDiv = document.createElement('div');
     delCardAlertDiv.className = 'modal';
     delCardAlertDiv.id = `deleteCardAlert-${cardId}`;
-    delCardAlertDiv.innerHTML = `
-        <p class="delObj"></p>
-        <button id="cancel-delete-card-button" class="modal-cancel-button">취소</button>
-        <button id="confirm-delete-card-button" class="modal-confirm-button">확인</button>
-    `;
+    delCardAlertDiv.innerHTML = deleteHTML('del-card');
     alertArea.appendChild(delCardAlertDiv);
+}
+
+// 칼럼 삭제
+export function createDeleteColumnAlert(columnId) {
+    const delColumnAlertDiv = document.createElement('div');
+    delColumnAlertDiv.className = 'modal';
+    delColumnAlertDiv.id = `deleteColumnAlert-${columnId}`;
+    delColumnAlertDiv.innerHTML = deleteHTML('del-column');
+    alertArea.appendChild(delColumnAlertDiv);
 }
 
 
@@ -21,11 +33,7 @@ export function createDeleteAllCardAlert(columnId) {
     const delAllCardAlertDiv = document.createElement('div');
     delAllCardAlertDiv.className = 'modal';
     delAllCardAlertDiv.id = `deleteAllCardAlert-${columnId}`;
-    delAllCardAlertDiv.innerHTML = `
-        <p class="delObj"></p>
-        <button id="cancel-delete-all-button" class="modal-cancel-button">취소</button>
-        <button id="confirm-delete-all-button" class="modal-confirm-button">확인</button>
-    `;
+    delAllCardAlertDiv.innerHTML = deleteHTML('del-all-card');
     alertArea.appendChild(delAllCardAlertDiv);
 }
 

--- a/js/card_action.js
+++ b/js/card_action.js
@@ -170,7 +170,8 @@ export function moveCard(event, clone) {
     clone.style.top = `${event.clientY-gapY}px`;
 }
 
-export function moveCardIllusion(newParent, clone) {
+export function moveCardIllusion(event, newParent, clone) {
+    if (!getIsDragging() || !clone) return;
     const columnArea = document.getElementById("column-area");
     [...columnArea.children].forEach((column)=> {
         let tempCard = column.querySelector(`#temp-${clone.id}`);
@@ -180,6 +181,18 @@ export function moveCardIllusion(newParent, clone) {
         }
     });
     let tempRealCard = newParent.querySelector(`#temp-${clone.id}`);
+    let cardList = event.target.closest('.card-list');
+    let closestCard = event.target.closest('.card-id');
+    let closestTempCard = event.target.closest('.temp-card');
+    if (cardList) {
+        if (closestCard) {
+            console.log(closestCard);
+            cardList.insertBefore(tempRealCard, closestCard);
+        } else if (!closestTempCard){
+            console.log("no!");
+            cardList.appendChild(tempRealCard);
+        }
+    }
     if (tempRealCard) {
         tempRealCard.className = "temp-card-true"
         tempRealCard.style.display = 'flex';
@@ -187,17 +200,17 @@ export function moveCardIllusion(newParent, clone) {
 }
 
 export function finishDragCard(clone) {
-    if (getIsDragging() && clone) {
-        const tempCards = document.querySelectorAll('.temp-card');
-        [...tempCards].forEach((tempCard)=>tempCard.remove());
-        const realCard = document.querySelector('.temp-card-true');
-        realCard.id = "card-id"+draggingCardId;
-        realCard.className = "card-id"
-        realCard.style.opacity = 1;
-        setEventForCard({"cardId": draggingCardId});
+    if (!getIsDragging() || !clone) return ;
 
-        toggleIsDragging();
-        clone.remove();
-        document.body.classList.remove('no-select');
-    }
+    const tempCards = document.querySelectorAll('.temp-card');
+    [...tempCards].forEach((tempCard)=>tempCard.remove());
+    const realCard = document.querySelector('.temp-card-true');
+    realCard.id = "card-id"+draggingCardId;
+    realCard.className = "card-id"
+    realCard.style.opacity = 1;
+    setEventForCard({"cardId": draggingCardId});
+
+    toggleIsDragging();
+    clone.remove();
+    document.body.classList.remove('no-select');
 }

--- a/js/card_action.js
+++ b/js/card_action.js
@@ -50,7 +50,7 @@ export function delCard(cardId) {
     });
 }
 
-export let isEditing = false;
+export let isCardEditing = false;
 
 // 카드 수정
 export function editCard(cardId) {
@@ -59,7 +59,7 @@ export function editCard(cardId) {
     const tempMemory = [...card.children];
     
     card.style.display = "block";
-    isEditing = true;
+    isCardEditing = true;
 
     let curTitle = card.querySelector(".card-title").textContent;
     let curContent = card.querySelector(".card-content").textContent;
@@ -83,12 +83,12 @@ export function editCard(cardId) {
     `;
 
     addListener(newActionDiv.querySelector('.confirm-button'),(event)=>{
-        isEditing = false;
+        isCardEditing = false;
         confirmEdit(card,cardId)
     });
 
     addListener(newActionDiv.querySelector('.cancel-button'),(event)=>{
-        isEditing = false;
+        isCardEditing = false;
         cancelEdit(card,tempMemory);
     });
     

--- a/js/card_action.js
+++ b/js/card_action.js
@@ -39,10 +39,10 @@ export function delCard(cardId) {
     delCardAlert.style.display = "block";
     let card = document.querySelector("#card-id"+cardId);
     delCardAlert.querySelector('.delObj').textContent = "선택한 카드를 삭제할까요?";
-    addListener(delCardAlert.querySelector('#cancel-delete-card-button'),(event)=>{
+    addListener(delCardAlert.querySelector('#cancel-del-card-button'),(event)=>{
         hideAlert();
     });
-    addListener(delCardAlert.querySelector('#confirm-delete-card-button'),(event)=>{
+    addListener(delCardAlert.querySelector('#confirm-del-card-button'),(event)=>{
         hideAlert();
         if (card) {
             card.remove();
@@ -95,6 +95,7 @@ export function editCard(cardId) {
     newInfoDiv.querySelector('#title-input').addEventListener('input', (event)=>{
         checkCardInput();
     });
+
     newInfoDiv.querySelector('#content-input').addEventListener('input', (event)=>{
         checkCardInput();
     });
@@ -173,8 +174,6 @@ export function moveCard(event, clone) {
 export function moveCardIllusion(newParent, clone) {
     const columnArea = document.getElementById("column-area");
     [...columnArea.children].forEach((column)=> {
-        console.log(column);
-        console.log(clone.id);
         let tempCard = column.querySelector(`#temp-${clone.id}`);
         if (tempCard) {
             tempCard.className = "temp-card"
@@ -198,7 +197,6 @@ export function finishDragCard(clone) {
         realCard.style.opacity = 1;
         setEventForCard({"cardId": draggingCardId});
 
-        console.log(realCard);
         isDragging = false;
         clone.remove();
         document.body.classList.remove('no-select');

--- a/js/card_action.js
+++ b/js/card_action.js
@@ -1,6 +1,12 @@
-import { addListener, renderTemplate, setEventForCard } from "./main.js";
+import { renderTemplate, setEventForCard } from "./main.js";
 import { createDeleteCardAlert, hideAlert, overlay } from "./alert.js";
 import { createNewId } from "./utility.js";
+import { addListener } from "./event_listeners.js";
+import { getIsDragging, toggleIsCardEditing, toggleIsDragging } from "./store.js";
+
+let gapX = 0;
+let gapY = 0;
+let draggingCardId = 0;
 
 // 입력창 확인 후 버튼 활성화 결정
 export function checkCardInput() {
@@ -50,8 +56,6 @@ export function delCard(cardId) {
     });
 }
 
-export let isCardEditing = false;
-
 // 카드 수정
 export function editCard(cardId) {
     let card = document.querySelector("#card-id"+cardId);
@@ -59,7 +63,7 @@ export function editCard(cardId) {
     const tempMemory = [...card.children];
     
     card.style.display = "block";
-    isCardEditing = true;
+    toggleIsCardEditing();
 
     let curTitle = card.querySelector(".card-title").textContent;
     let curContent = card.querySelector(".card-content").textContent;
@@ -83,12 +87,12 @@ export function editCard(cardId) {
     `;
 
     addListener(newActionDiv.querySelector('.confirm-button'),(event)=>{
-        isCardEditing = false;
+        toggleIsCardEditing();
         confirmEdit(card,cardId)
     });
 
     addListener(newActionDiv.querySelector('.cancel-button'),(event)=>{
-        isCardEditing = false;
+        toggleIsCardEditing();
         cancelEdit(card,tempMemory);
     });
     
@@ -129,13 +133,8 @@ function cancelEdit(card, tempMemory){
     });
 }
 
-export let isDragging = false;
-let gapX = 0;
-let gapY = 0;
-let draggingCardId = 0;
-
 export function startDragCard(event, original, clone, cardId) {
-    isDragging = true;
+    toggleIsDragging();
     const childElement = document.querySelector("#card-id"+cardId);
     clone.style.width = window.getComputedStyle(childElement).width;
     draggingCardId = cardId;
@@ -165,7 +164,7 @@ export function startDragCard(event, original, clone, cardId) {
 }
 
 export function moveCard(event, clone) {
-    if (!isDragging || !clone) return;
+    if (!getIsDragging() || !clone) return;
 
     clone.style.left = `${event.clientX-gapX}px`;
     clone.style.top = `${event.clientY-gapY}px`;
@@ -188,7 +187,7 @@ export function moveCardIllusion(newParent, clone) {
 }
 
 export function finishDragCard(clone) {
-    if (isDragging && clone) {
+    if (getIsDragging() && clone) {
         const tempCards = document.querySelectorAll('.temp-card');
         [...tempCards].forEach((tempCard)=>tempCard.remove());
         const realCard = document.querySelector('.temp-card-true');
@@ -197,7 +196,7 @@ export function finishDragCard(clone) {
         realCard.style.opacity = 1;
         setEventForCard({"cardId": draggingCardId});
 
-        isDragging = false;
+        toggleIsDragging();
         clone.remove();
         document.body.classList.remove('no-select');
     }

--- a/js/column_action.js
+++ b/js/column_action.js
@@ -1,4 +1,4 @@
-import { overlay, createDeleteAllCardAlert, hideAlert } from "./alert.js";
+import { overlay, createDeleteAllCardAlert, createDeleteColumnAlert, hideAlert } from "./alert.js";
 import { checkCardInput, confirmAddCard } from "./card_action.js";  
 import { addListener } from "./main.js";
 
@@ -50,6 +50,24 @@ export function addCard(id) {
     }
 }
 
+export function delColumn(columnId) {
+    overlay.style.display = "block";
+    createDeleteColumnAlert(columnId);
+    let delColumnAlert = document.getElementById(`deleteColumnAlert-${columnId}`);
+    delColumnAlert.style.display = "block";
+    delColumnAlert.querySelector('.delObj').textContent = "칼럼을 삭제하시겠습니까?";
+    let cardList = document.getElementById("card-list"+columnId);
+
+    delColumnAlert.querySelector('#cancel-del-column-button').addEventListener('click',(event)=>{
+        hideAlert();
+    });
+    delColumnAlert.querySelector('#confirm-del-column-button').addEventListener('click',(event)=>{
+        overlay.style.display = "none";
+        hideAlert();
+        document.getElementById(`column-id${columnId}`).remove();
+    });
+}
+
 
 export function delAllCard(columnId) {
     overlay.style.display = "block";
@@ -59,10 +77,10 @@ export function delAllCard(columnId) {
     delAllCardAlert.querySelector('.delObj').textContent = "칼럼의 모든 카드를 삭제하시겠습니까?";
     let cardList = document.getElementById("card-list"+columnId);
 
-    delAllCardAlert.querySelector('#cancel-delete-all-button').addEventListener('click',(event)=>{
+    delAllCardAlert.querySelector('#cancel-del-all-card-button').addEventListener('click',(event)=>{
         hideAlert();
     });
-    delAllCardAlert.querySelector('#confirm-delete-all-button').addEventListener('click',(event)=>{
+    delAllCardAlert.querySelector('#confirm-del-all-card-button').addEventListener('click',(event)=>{
         overlay.style.display = "none";
         hideAlert();
         cardList.innerHTML = ``;
@@ -158,4 +176,16 @@ export function completeColumnName() {
     [...document.querySelectorAll('.column-name')].map((element)=>{
         element.contentEditable = "false";
     });
+}
+
+export function toggleColumnShadow() {
+    let main = document.querySelector('main');
+    let scrollElement = document.querySelector('#column-area');
+    const scrollWidth = scrollElement.scrollWidth;
+    const clientWidth = scrollElement.clientWidth;
+    if (scrollWidth > clientWidth) {
+        main.classList.remove('hidden');
+    } else {
+        main.classList.add('hidden');
+    }
 }

--- a/js/column_action.js
+++ b/js/column_action.js
@@ -1,6 +1,9 @@
 import { overlay, createDeleteAllCardAlert, createDeleteColumnAlert, hideAlert } from "./alert.js";
 import { checkCardInput, confirmAddCard } from "./card_action.js";  
-import { addListener } from "./main.js";
+import { addListener } from "./event_listeners.js";
+import { getIsOrderChanging, toggleIsColumnNameChanging, toggleIsOrderChanging } from "./store.js";
+
+let sortingOrder = 1;
 
 export function addCard(id) {
     const parentElement = document.querySelector('#column-id'+id);
@@ -99,11 +102,8 @@ export function updateChildCount(parentElement) {
     }
 }
 
-let sortingOrder = 1;
-export let isOrderChanging = false;
-
 export function toggleSortOrder() {
-    if (!isOrderChanging) {
+    if (!getIsOrderChanging()) {
         sortingOrder *= -1;
         let chip = document.querySelector('.chip');
         if (sortingOrder==1) {
@@ -111,9 +111,9 @@ export function toggleSortOrder() {
         } else {
             chip.querySelector('div').textContent = "최신 순";
         }
-        isOrderChanging = true;
+        toggleIsOrderChanging();
         sortColumns();
-        setTimeout(()=>{isOrderChanging = false}, 500)
+        setTimeout(()=>{toggleIsOrderChanging();}, 500)
     }
 }
 
@@ -163,16 +163,15 @@ function sortColumns() {
     });
 }
 
-export let isColumnNameChanging = false;
 
 export function changeColumnName(event) {
-    isColumnNameChanging = true;
+    toggleIsColumnNameChanging();
     event.target.contentEditable = "true";
     event.target.focus();
 }
 
 export function completeColumnName() {
-    isColumnNameChanging = false;
+    toggleIsColumnNameChanging();
     [...document.querySelectorAll('.column-name')].map((element)=>{
         element.contentEditable = "false";
     });

--- a/js/column_action.js
+++ b/js/column_action.js
@@ -82,10 +82,10 @@ export function updateChildCount(parentElement) {
 }
 
 let sortingOrder = 1;
-export let isMoving = false;
+export let isOrderChanging = false;
 
 export function toggleSortOrder() {
-    if (!isMoving) {
+    if (!isOrderChanging) {
         sortingOrder *= -1;
         let chip = document.querySelector('.chip');
         if (sortingOrder==1) {
@@ -93,9 +93,9 @@ export function toggleSortOrder() {
         } else {
             chip.querySelector('div').textContent = "최신 순";
         }
-        isMoving = true;
+        isOrderChanging = true;
         sortColumns();
-        setTimeout(()=>{isMoving = false}, 500)
+        setTimeout(()=>{isOrderChanging = false}, 500)
     }
 }
 
@@ -142,5 +142,20 @@ function sortColumns() {
                 });
             }, 500);
         } 
+    });
+}
+
+export let isColumnNameChanging = false;
+
+export function changeColumnName(event) {
+    isColumnNameChanging = true;
+    event.target.contentEditable = "true";
+    event.target.focus();
+}
+
+export function completeColumnName() {
+    isColumnNameChanging = false;
+    [...document.querySelectorAll('.column-name')].map((element)=>{
+        element.contentEditable = "false";
     });
 }

--- a/js/delete_column_button.js
+++ b/js/delete_column_button.js
@@ -1,0 +1,7 @@
+export function deleteColumnButton() {
+    const newDiv = document.createElement('button');
+    newDiv.id = 'delete-column-button';
+    newDiv.className = 'icon-button material-icons'
+    newDiv.innerHTML = `delete`;
+    return newDiv;
+}

--- a/js/event_listeners.js
+++ b/js/event_listeners.js
@@ -1,0 +1,89 @@
+import { toggleSortOrder,completeColumnName,  } from "./column_action.js";
+import { moveCard, finishDragCard } from "./card_action.js";
+import { getClone, getIsCardEditing, getIsColumnNameChanging, getIsDragging, getIsOrderChanging, setClone } from "./store.js";
+import { renderTemplate } from "./main.js";
+
+const eventListeners = new WeakMap();
+
+export function addListener(element, listener) {
+    if (!eventListeners.has(element)) {
+      eventListeners.set(element, []); // 요소에 대한 리스너 배열 초기화
+    }
+    eventListeners.get(element).push(listener); // 배열에 리스너 추가
+}
+
+function triggerListeners(event, startElement) {
+    let currentElement = startElement;
+
+    while (currentElement) {
+        if (eventListeners.has(currentElement)) {
+            const listeners = eventListeners.get(currentElement);
+            if (listeners) {
+                listeners.forEach((listener) => listener(event, currentElement)); // 등록된 모든 리스너 실행
+                break;
+            }
+        }
+        currentElement = currentElement.parentElement; // 부모로 이동
+    }
+}
+
+document.addEventListener('click', (event) => {
+    if (!getIsOrderChanging()) {
+        triggerListeners(event, event.target);
+    }
+    if (getIsColumnNameChanging() && !event.target.closest('.column-name')) {
+        completeColumnName();
+    }
+});
+
+document.addEventListener('dblclick', (event) => {
+    if (!getIsOrderChanging()) {
+        triggerListeners(event, event.target);
+    }
+});
+
+document.addEventListener('mousedown', (event) => {
+    if (!getIsCardEditing() && !getIsOrderChanging()) {
+        triggerListeners(event, event.target);
+    }
+});
+
+document.addEventListener('mousemove', (event) => {
+    if (getIsDragging()) {
+        triggerListeners(event, event.target)
+    }
+});
+
+document.addEventListener('mouseup', (event) => {
+    if (getIsDragging()) {
+        finishDragCard(getClone());
+        setClone(null);
+    }
+});
+
+
+document.addEventListener('keydown', (event) => {
+    if (getIsColumnNameChanging()) {
+        triggerListeners(event, event.target);
+    }
+});
+
+
+
+
+addListener(document.body, (event)=>{
+    moveCard(event, getClone());
+})
+
+addListener(document.querySelector('.chip'), (event) =>{
+    if (event.type === "click") {
+        toggleSortOrder();
+    }
+});
+
+addListener(document.querySelector('.fab'), (event)=>{
+    if (event.type === "click") {
+        let newColumnId = document.querySelector("#column-area").childElementCount;
+        renderTemplate('./html/column_template.html', 'column-template', 'column-area', {columnId:newColumnId, title:"제목없음"});
+    }
+})

--- a/js/history.js
+++ b/js/history.js
@@ -23,3 +23,7 @@ function showHistory() {
     dialog.style.left = `${dialogX}px`;
     dialog.style.top = `${dialogY}px`;
 }
+
+function addHistory() {
+    
+}

--- a/js/main.js
+++ b/js/main.js
@@ -85,7 +85,7 @@ function setEventForColumn(props) {
     addListener(parentElement,(event)=>{
         if (event.type === "mousemove") {
             moveCard(event, getClone());
-            moveCardIllusion(parentElement, getClone());
+            moveCardIllusion(event, parentElement, getClone());
         }
     })
 
@@ -140,7 +140,7 @@ export function setEventForCard(props) {
             }
         } else if (event.type === "mousemove") {
             moveCard(event, getClone());
-            moveCardIllusion(parentElement, getClone());
+            moveCardIllusion(event, parentElement, getClone());
         }
     });
 }

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
-import { addCard, delAllCard, updateChildCount, toggleSortOrder, isMoving  } from "./column_action.js";
-import { editCard, delCard, startDragCard, moveCard, finishDragCard, isDragging, moveCardIllusion, isEditing } from "./card_action.js";
+import { addCard, delAllCard, updateChildCount, toggleSortOrder, changeColumnName, isOrderChanging, completeColumnName, isColumnNameChanging  } from "./column_action.js";
+import { editCard, delCard, startDragCard, moveCard, finishDragCard, isDragging, moveCardIllusion, isCardEditing } from "./card_action.js";
 
 // 탬플릿에 Props 적용
 function adaptProps(component, templateId, props) {
@@ -76,6 +76,17 @@ function setEventForColumn(props) {
         if (event.type === "mousemove") {
             moveCard(event, clone);
             moveCardIllusion(parentElement, clone);
+        }
+    })
+
+
+    addListener(parentElement.querySelector('.column-name'), (event)=>{
+        if (event.type === "dblclick") {
+            changeColumnName(event);
+        } else if (event.type === 'keydown') {
+            if (event.key === 'Enter') {
+                completeColumnName();
+            }
         }
     })
 
@@ -171,13 +182,22 @@ addListener(document.querySelector('.chip'), (event) =>{
 });
 
 document.addEventListener('click', (event) => {
-    if (!isMoving) {
+    if (!isOrderChanging) {
+        triggerListeners(event, event.target);
+    }
+    if (isColumnNameChanging && !event.target.closest('.column-name')) {
+        completeColumnName();
+    }
+});
+
+document.addEventListener('dblclick', (event) => {
+    if (!isOrderChanging) {
         triggerListeners(event, event.target);
     }
 });
 
 document.addEventListener('mousedown', (event) => {
-    if (!isEditing && !isMoving) {
+    if (!isCardEditing && !isOrderChanging) {
         triggerListeners(event, event.target);
     }
 });
@@ -192,6 +212,13 @@ document.addEventListener('mouseup', (event) => {
     if (isDragging) {
         finishDragCard(clone);
         clone = null;
+    }
+});
+
+
+document.addEventListener('keydown', (event) => {
+    if (isColumnNameChanging) {
+        triggerListeners(event, event.target);
     }
 });
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
-import { addCard, delAllCard, updateChildCount, toggleSortOrder, changeColumnName, isOrderChanging, completeColumnName, isColumnNameChanging  } from "./column_action.js";
+import { addCard, delAllCard, updateChildCount, toggleSortOrder, changeColumnName, isOrderChanging, completeColumnName, isColumnNameChanging, delColumn, toggleColumnShadow  } from "./column_action.js";
 import { editCard, delCard, startDragCard, moveCard, finishDragCard, isDragging, moveCardIllusion, isCardEditing } from "./card_action.js";
+import { deleteColumnButton } from "./delete_column_button.js";
 
 // 탬플릿에 Props 적용
 function adaptProps(component, templateId, props) {
@@ -9,6 +10,9 @@ function adaptProps(component, templateId, props) {
             component.querySelector('#column-id').id += props.columnId;
             component.querySelector('.column-name').textContent = props.title || 'Default Title';
             component.querySelector('#card-list').id += props.columnId;
+            if (!(props.isDefault || false)) {
+                component.querySelector('.column-header-right').prepend(deleteColumnButton());
+            }
             updateChildCount(component.querySelector('.column-id'));
         } else if (templateId==='card-template') {
             component.querySelector('#card-id').id += props.cardId;
@@ -56,7 +60,11 @@ function adaptEventListener(targetId, props) {
 // 칼럼 이벤트 적용
 function setEventForColumn(props) {
     const parentElement = document.querySelector('#column-id'+props.columnId);
-
+    if (!props.isDefault) {
+        addListener(parentElement.querySelector('#delete-column-button'), (event) => {
+            delColumn(props.columnId);
+        });
+    }
     addListener(parentElement.querySelector('#add-card-button'), (event)=>{
         if (event.type === "click") {
             addCard(props.columnId);
@@ -78,7 +86,6 @@ function setEventForColumn(props) {
             moveCardIllusion(parentElement, clone);
         }
     })
-
 
     addListener(parentElement.querySelector('.column-name'), (event)=>{
         if (event.type === "dblclick") {
@@ -181,6 +188,13 @@ addListener(document.querySelector('.chip'), (event) =>{
     }
 });
 
+addListener(document.querySelector('.fab'), (event)=>{
+    if (event.type === "click") {
+        let newColumnId = document.querySelector("#column-area").childElementCount;
+        renderTemplate('./html/column_template.html', 'column-template', 'column-area', {columnId:newColumnId, title:"제목없음"});
+    }
+})
+
 document.addEventListener('click', (event) => {
     if (!isOrderChanging) {
         triggerListeners(event, event.target);
@@ -222,6 +236,16 @@ document.addEventListener('keydown', (event) => {
     }
 });
 
-renderTemplate('./html/column_template.html', 'column-template', 'column-area', {columnId:0, title:"해야할 일"});
-renderTemplate('./html/column_template.html', 'column-template', 'column-area', {columnId:1, title:"하고 있는 일"});
-renderTemplate('./html/column_template.html', 'column-template', 'column-area', {columnId:2, title:"완료한 일"});
+// MutationObserver 설정
+const observer = new MutationObserver(() => {
+    toggleColumnShadow();
+});
+
+// MutationObserver를 관찰할 대상과 옵션 설정
+observer.observe(document.querySelector('#column-area'), {
+    childList: true,
+});
+
+renderTemplate('./html/column_template.html', 'column-template', 'column-area', {columnId:0, title:"해야할 일", isDefault: true});
+renderTemplate('./html/column_template.html', 'column-template', 'column-area', {columnId:1, title:"하고 있는 일", isDefault: true});
+renderTemplate('./html/column_template.html', 'column-template', 'column-area', {columnId:2, title:"완료한 일", isDefault: true});

--- a/js/store.js
+++ b/js/store.js
@@ -1,0 +1,49 @@
+let clone = null;
+let isOrderChanging = false;
+let isColumnNameChanging = false;
+let isCardEditing = false;
+let isDragging = false;
+
+export function getClone () {
+    return clone;
+}
+
+export function setClone (newClone) {
+    clone = newClone;
+}
+
+
+export function getIsOrderChanging () {
+    return isOrderChanging;
+}
+
+export function toggleIsOrderChanging () {
+    isOrderChanging = !isOrderChanging;
+}
+
+
+export function getIsColumnNameChanging () {
+    return isColumnNameChanging;
+}
+
+export function toggleIsColumnNameChanging () {
+    isColumnNameChanging = !isColumnNameChanging;
+}
+
+
+export function getIsCardEditing () {
+    return isCardEditing;
+}
+
+export function toggleIsCardEditing () {
+    isCardEditing = !isCardEditing;
+}
+
+
+export function getIsDragging () {
+    return isDragging;
+}
+
+export function toggleIsDragging () {
+    isDragging = !isDragging;
+}


### PR DESCRIPTION
## 주요 작업
칼럼명을 더블클릭으로 변경할 수 있도록 하였습니다. (바깥 클릭 또는 엔터키입력으로 수정 완료)
칼럼을 추가/삭제 할 수 있도록 하였습니다. (칼럼 늘어나면 오른쪽으로 스크롤 + 그림자로 늘어났음을 표시)
카드 이동 자유롭게 할 수 있도록 수정하였습니다. (원하는 순서에 넣기 가능)
https://drive.google.com/file/d/1_jji3UpzlcXMiieM5sJ1nXkl-5xc8E14/view?usp=drive_link
https://drive.google.com/file/d/14iQeO5OvXVi0G41GGfBiYRFZCRhUkn19/view?usp=drive_link

## 학습 키워드
이벤트 리스너, DOM API, CSS

## 고민과 해결과정
칼럼이 늘어나면 오른쪽으로 스크롤이 생기는데, 스크롤할 수 있는것을 인지시키기 위한 그림자를 넣는게 까다로웠음. -> CSS의 ::after 속성과 hidden이라는 클래스를 추가해줌으로써 구현 성공