### PR TITLE
[FE 윤동현] - Taskify | Task 이동 애니메이션 적용 & Log상태 옵저빙 패턴 적용 & Log Undo Redo 시스템 구현 (ADD, REMOVE, MOVE)

### DIFF
--- a/components/column.js
+++ b/components/column.js
@@ -48,7 +48,7 @@ export default function ColumnComponent() {
         addButton.addEventListener("click", () =>
             handleAdd(formContainer, columnIdx)
         );
-        const listElement = columnElement.querySelector('.card_list')
+        const listElement = columnElement.querySelector(".card_list");
         listElement.addEventListener("dragover", (e) => e.preventDefault());
         listElement.addEventListener("drop", handleDrop);
         listElement.addEventListener("dragenter", handleDragEnter);
@@ -60,12 +60,6 @@ export default function ColumnComponent() {
             ".column_task_counter"
         )[idx];
         if (n > MAX_TASKS) counterElement.textContent`${MAX_TASKS}+`;
-        else counterElement.textContent = n;
-    }
-
-    function rerenderHeader(idx, n) {
-        const counterElement = document.body.querySelectorAll('.column_task_counter')[idx];
-        if(n > MAX_TASKS) counterElement.textContent `${MAX_TASKS}+`;
         else counterElement.textContent = n;
     }
 

--- a/components/fab.js
+++ b/components/fab.js
@@ -1,0 +1,24 @@
+export default function FabComponent() {
+    function template(icon) {
+        return `
+            <img src='/public/icon/${icon}.svg' width="32" height="32"/>
+        `
+    }
+
+    function render(icon, background) {
+        const buttonElement = document.createElement('button');
+        buttonElement.classList = `rounded-500 flex-center shadow-up fab_button ${background}`;
+        buttonElement.innerHTML = template(icon);
+
+        return buttonElement
+    }
+
+    function addListener(buttonElement, handleClick) {
+        buttonElement.addEventListener('click', handleClick);
+    }
+
+    return {
+        render,
+        addListener
+    }
+}

--- a/components/task.js
+++ b/components/task.js
@@ -52,8 +52,6 @@ export default function TaskComponent() {
         deleteButton.addEventListener("click", handleRemove );
         editButton.addEventListener("click", handleUpdate );   
     
-        taskElement.addEventListener('dragenter',(e)=>e.stopPropagation());
-        // taskElement.addEventListener('dragleave',(e)=>e.stopPropagation());
         taskElement.addEventListener("dragstart", handleDrag);
     }
 

--- a/public/globals.css
+++ b/public/globals.css
@@ -161,3 +161,9 @@ body {
 .rounded-500 {
     border-radius: 50%;
 }
+
+.flex-center {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}

--- a/public/globals.css
+++ b/public/globals.css
@@ -4,6 +4,10 @@
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+
+    ::-webkit-scrollbar {
+        display: none;
+      }
 }
 
 button {

--- a/public/icon/redo.svg
+++ b/public/icon/redo.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M24.4448 14.2222H12.0003C4.88921 14.2222 4.88921 24 12.0003 24M24.4448 14.2222L18.2225 8M24.4448 14.2222L18.2225 20.4444" stroke="#6E7191" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/icon/undo.svg
+++ b/public/icon/undo.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.66699 14.2222H19.1114C26.2225 14.2222 26.2225 24 19.1114 24M6.66699 14.2222L12.8892 8M6.66699 14.2222L12.8892 20.4444" stroke="#6E7191" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/public/main.css
+++ b/public/main.css
@@ -205,3 +205,18 @@ header > span {
         text-align: center;
     }
 }
+
+#fab_container {
+    position: absolute;
+    right: 48px;
+    bottom: 48px;    
+}
+
+.fab_button {
+    padding: 12px;
+    margin-bottom: 16px;
+    
+    &:last-of-type {
+        margin: 0px;
+    }
+}

--- a/public/main.css
+++ b/public/main.css
@@ -153,6 +153,8 @@ header > span {
 }
 
 #log_layer_list {
+    overflow: auto;
+    max-height: 600px;
     margin: 8px 0;
 }
 

--- a/script/column.js
+++ b/script/column.js
@@ -196,9 +196,9 @@ export default function ColumnController(state, bodyElement, logStore) {
             created: new Date(),
         };
 
-        state.addTask(columnIdx, newTask);
+        const newId = state.addTask(columnIdx, newTask);
         logStore.addLog({
-            task: newTask,
+            task: {...newTask, taskId: newId},
             type: "ADD",
             updated: new Date(),
         })

--- a/script/column.js
+++ b/script/column.js
@@ -2,11 +2,11 @@ import FormComponent from "../components/Form.js";
 import ColumnComponent from "../components/column.js";
 import TaskController from "./task.js";
 
-export default function ColumnController(state, bodyElement) {
+export default function ColumnController(state, bodyElement, logStore) {
     const { columns: columnList, columnTasks } = state.getColumns();
     const columnComponent = ColumnComponent();
     const formComponent = FormComponent();
-    const taskController = TaskController(state, (idx)=>{
+    const taskController = TaskController(state, logStore, (idx)=>{
         renderColumn(idx, columnTasks[idx]);
     });
     
@@ -21,7 +21,13 @@ export default function ColumnController(state, bodyElement) {
         resetDrop();
         columnListElement.appendChild(element);
 
-        state.moveTask(columnIdx, task)
+        state.moveTask(columnIdx, task);
+        logStore.addLog({
+            task: task,
+            type: "MOVE",
+            updated: new Date(),
+            destination: columnIdx
+        })
         state.resetDragged();
 
         renderColumn(startIdx, state.sortTask(columnTasks[startIdx]))
@@ -191,6 +197,11 @@ export default function ColumnController(state, bodyElement) {
         };
 
         state.addTask(columnIdx, newTask);
+        logStore.addLog({
+            task: newTask,
+            type: "ADD",
+            updated: new Date(),
+        })
         renderColumn(columnIdx, state.sortTask(columnTasks[columnIdx]));
     }
 

--- a/script/fab.js
+++ b/script/fab.js
@@ -1,0 +1,96 @@
+import FabComponent from "../components/fab.js";
+import ColumnController from "./column.js";
+
+export default function FabController(bodyElement, state, logStore) {
+    const fabComponent = FabComponent();
+    const columnController = ColumnController(state, bodyElement, logStore);
+    const {columns, columnTasks} = state.getColumns();
+
+    function handleRedo() {
+        const log = logStore.redo();
+        if(!log || log === undefined) return;
+
+        const {type, task, updated, destination} = log;
+
+        const columnIdx = task.column;
+
+        switch(type) {
+            case "ADD":
+                state.addTask(columnIdx, task, task.taskId);
+                columnController.renderColumn(columnIdx, state.sortTask(columnTasks[columnIdx]))
+                break;
+            case "REMOVE":
+                state.removeTask(task)
+                columnController.renderColumn(columnIdx, state.sortTask(columnTasks[columnIdx]))
+                break;
+            case "UPDATE":
+                console.log('TOBE ');
+                break;
+            case "MOVE":
+                state.moveTask(destination, task);
+
+                columnController.renderColumn(task.column, state.sortTask(columnTasks[task.column]))
+                columnController.renderColumn(destination, state.sortTask(columnTasks[destination]))
+                break;
+        }
+
+    }
+
+    function handleUndo() {
+        const log = logStore.undo();
+        if(!log || log === undefined) return;
+
+        const {type, task, updated, destination, origin} = log;
+
+        const columnIdx = task.column;
+
+        const flippedType = flip(type);
+
+        switch(flippedType) {   
+            case "ADD":
+                state.addTask(columnIdx, task, task.taskId);
+                columnController.renderColumn(columnIdx, state.sortTask(columnTasks[columnIdx]))
+                break;
+            case "REMOVE":
+                state.removeTask(task)
+                columnController.renderColumn(columnIdx, state.sortTask(columnTasks[columnIdx]))
+                break;
+            case "UPDATE":
+                console.log('TOBE');
+                break;
+            case "MOVE":
+                const originColumn = task.column;
+                const newTask = {...task, column: destination}
+
+                state.moveTask(originColumn, newTask);
+
+                columnController.renderColumn(originColumn, state.sortTask(columnTasks[originColumn]))
+                columnController.renderColumn(destination, state.sortTask(columnTasks[destination]))
+                break;
+        }
+
+        
+    }
+
+    function renderInit() {
+        const container = document.createElement("div");
+        container.setAttribute("id", "fab_container");
+        const redoElement = fabComponent.render("redo", "surface-default");
+        fabComponent.addListener(redoElement, handleRedo);
+        container.appendChild(redoElement);
+
+        const undoElement = fabComponent.render("undo", "surface-default");
+        fabComponent.addListener(undoElement, handleUndo);
+        container.appendChild(undoElement);
+        bodyElement.appendChild(container);
+    }
+
+    function flip(input) {
+        return input === "ADD" ? "REMOVE" : input === "REMOVE" ? "ADD" : input;
+      }
+      
+
+    return {
+        renderInit,
+    };
+}

--- a/script/header.js
+++ b/script/header.js
@@ -3,48 +3,34 @@ import { LogComponent } from "../components/log.js";
 import ModalComponent from "../components/modal.js";
 import ColumnController from "./column.js";
 
-export default function HeaderController(state, bodyElement) {
-    const {columns, columnTasks} = state.getColumns();
+export default function HeaderController(state, bodyElement, logStore) {
+    const { columns, columnTasks } = state.getColumns();
     const headerComponent = HeaderComponent();
-    const logComponent = LogComponent(columns);
+    const logComponent = LogComponent(columns, logStore, renderClearLogModal);
 
     // Column 동적 생성 및 이벤트 등록
     function renderInit() {
         const headerElement = headerComponent.render();
-        headerComponent.addEventListener(
-            headerElement,
-            handleSort,
-            renderLog
-        );
+        headerComponent.addEventListener(headerElement, handleSort, renderLog);
 
         bodyElement.appendChild(headerElement);
     }
 
     function renderClearLogModal() {
         const modalComponent = ModalComponent();
-        modalComponent.render('모든 사용자 활동 기록을 삭제할까요?',
-            ()=>{
-                state.clearLog();
-                renderLog();
-                renderLog();
-            }
-        )
+        modalComponent.render("모든 사용자 활동 기록을 삭제할까요?", () =>
+            logStore.clearLog()
+        );
     }
 
     function renderLog() {
-        const logs = state.getLog();
+        const logs = logStore.getLogs();
         const existLogElement = bodyElement.querySelector("#log_layer");
 
         if (existLogElement) {
             logComponent.remove();
         } else {
             const logElement = logComponent.render(logs);
-
-            logComponent.addEventListener(
-                logElement,
-                () => logComponent.remove(),
-                renderClearLogModal
-            );
             bodyElement.appendChild(logElement);
         }
     }
@@ -53,13 +39,12 @@ export default function HeaderController(state, bodyElement) {
         const columnController = ColumnController(state, bodyElement);
         const currentOrder = state.flipOrder();
 
-        for(let i=0; i<columns.length; i++) {
+        for (let i = 0; i < columns.length; i++) {
             columnController.renderColumn(i, state.sortTask(columnTasks[i]));
         }
 
         return currentOrder;
     }
-
 
     return {
         renderInit,

--- a/script/index.js
+++ b/script/index.js
@@ -1,4 +1,5 @@
 import ColumnController from "./column.js";
+import FabController from "./fab.js";
 import HeaderController from "./header.js";
 import State from "./state.js";
 import LogStore from "./store/log.js";
@@ -8,5 +9,8 @@ const logStore = new LogStore();
 const body = document.body;
 const headerController = HeaderController(state, body, logStore);
 const columnController = ColumnController(state, body, logStore);
+const fabController = FabController(body, state, logStore);
+
 headerController.renderInit();
 columnController.renderInit();
+fabController.renderInit();

--- a/script/index.js
+++ b/script/index.js
@@ -1,10 +1,12 @@
 import ColumnController from "./column.js";
 import HeaderController from "./header.js";
 import State from "./state.js";
+import LogStore from "./store/log.js";
 
 const state = State();
+const logStore = new LogStore();
 const body = document.body;
-const headerController = HeaderController(state, body);
-const columnController = ColumnController(state, body);
+const headerController = HeaderController(state, body, logStore);
+const columnController = ColumnController(state, body, logStore);
 headerController.renderInit();
 columnController.renderInit();

--- a/script/state.js
+++ b/script/state.js
@@ -72,16 +72,26 @@ export default function State() {
         }
     }
 
-    function addTask(index, task) {
-        const newId = taskId++;
-        const newTask = {
-            ...task,
-            taskId: newId,
-        };
+    function addTask(index, task, id) {
+        let newTask = null;
+        let newId = null;
         
+        if(id === undefined) {
+            newId = taskId++;
+            newTask = {
+                ...task,
+                taskId: newId,
+            };
+        }
+        else {
+            newTask = {
+                ...task,
+                taskId: id,
+            };
+        }
         columnTasks[index].push(newTask);
 
-        return newId;
+        return id === undefined ? newId : id;
     }
 
     function moveTask(destinationIndex, task) {

--- a/script/state.js
+++ b/script/state.js
@@ -17,27 +17,12 @@ export default function State() {
             index: 2,
         },
     ];
-    let logs = [];
 
     let dragged = {
         task: null,
         element: null,
         dummyElement: null,
     };
-
-    function setLog(log) {
-        if (logs.length >= 5) {
-            logs = [...logs.slice(1), log];
-        } else logs.push(log);
-    }
-
-    function getLog() {
-        return logs;
-    }
-
-    function clearLog() {
-        logs = [];
-    }
 
     function getOrder() {
         return orderingState;
@@ -93,11 +78,7 @@ export default function State() {
             ...task,
             taskId: newId,
         };
-        setLog({
-            task: newTask,
-            type: "ADD",
-            updated: new Date(),
-        });
+        
         columnTasks[index].push(newTask);
 
         return newId;
@@ -107,34 +88,16 @@ export default function State() {
         const newTask = {...task, column : destinationIndex};
         const currentIndex = task.column;
 
-        setLog({
-            task: task,
-            type: "MOVE",
-            updated: new Date(),
-            destination: destinationIndex
-        })
-
         columnTasks[currentIndex] = columnTasks[currentIndex].filter(el => el.taskId !== task.taskId);
         columnTasks[destinationIndex].push(newTask);
     }
 
     function updateTask(index, currentTask, newTask) {
-        setLog({
-            task: currentTask,
-            type: "UPDATE",
-            updated: new Date(),
-        });
-
         const taskIndex = columnTasks[index].indexOf(currentTask);
         columnTasks[index][taskIndex] = {...newTask, taskId: currentTask.taskId};
     }
 
     function removeTask(task) {
-        setLog({
-            task: task,
-            type: "REMOVE",
-            updated: new Date(),
-        });
         const index = task.column;
         columnTasks[index] = columnTasks[index].filter((el) => el.taskId != task.taskId);
     }
@@ -157,8 +120,6 @@ export default function State() {
         moveTask,
         updateTask,
         removeTask,
-        getLog,
-        clearLog,
         sortTask, 
     };
 }

--- a/script/store/log.js
+++ b/script/store/log.js
@@ -1,0 +1,27 @@
+import Observable from "./store.js";
+
+class LogStore extends Observable {
+    #logId = 0;
+    #logs;
+    constructor() {
+        super();
+        this.#logs = [];
+    }
+
+    addLog(log) {
+        this.#logs.push({...log, logId: this.#logId});
+        this.#logId++;
+        this.notify(this.#logs);
+    }
+
+    clearLog() {
+        this.#logs = [];
+        this.notify(this.#logs);
+    }
+
+    getLogs() {
+        return this.#logs;
+    }
+}
+
+export default LogStore;

--- a/script/store/log.js
+++ b/script/store/log.js
@@ -1,14 +1,18 @@
 import Observable from "./store.js";
 
 class LogStore extends Observable {
-    #logId = 0;
+    #logId;
     #logs;
+    #logPointer
     constructor() {
         super();
         this.#logs = [];
+        this.#logId = 0;
+        this.#logPointer = 0;
     }
 
     addLog(log) {
+        this.#logPointer = 0;
         this.#logs.push({...log, logId: this.#logId});
         this.#logId++;
         this.notify(this.#logs);
@@ -21,6 +25,24 @@ class LogStore extends Observable {
 
     getLogs() {
         return this.#logs;
+    }
+
+    #getCurrentLog(index) {
+        return this.#logs[index];
+    }
+
+    undo() {
+        if(this.#logPointer >= this.#logs.length || this.#logPointer === 4) return undefined;
+        const index = this.#logs.length -1 - this.#logPointer;
+        this.#logPointer++;
+        return this.#getCurrentLog(index);
+    }
+
+    redo() {
+        if(this.#logPointer === 0 ) return undefined;
+        this.#logPointer--;
+        const index = this.#logs.length -1 - this.#logPointer;
+        return this.#getCurrentLog(index);
     }
 }
 

--- a/script/store/store.js
+++ b/script/store/store.js
@@ -1,0 +1,18 @@
+class Observable {
+    #observers;
+    
+    constructor() {
+        this.#observers = new Set();
+    }
+    subscribe(observer) {
+        this.#observers.add(observer);
+    }
+    unsubscribe(observer) {
+        this.#observers.delete(observer);
+    }
+    notify(data) {
+        this.#observers.forEach(observer => observer(data));
+    }
+}
+
+export default Observable

--- a/script/task.js
+++ b/script/task.js
@@ -2,7 +2,7 @@ import ModalComponent from "../components/modal.js";
 import FormComponent from "../components/Form.js";
 import TaskComponent from "../components/task.js";
 
-export default function TaskController(state, rerender) {
+export default function TaskController(state, logStore, rerender) {
     const formComponent = FormComponent();
     const taskComponent = TaskComponent();
 
@@ -53,6 +53,11 @@ export default function TaskController(state, rerender) {
 
         modalComponent.render("선택한 카드를 삭제할까요?", () => {
             state.removeTask(task);
+            logStore.addLog({
+                task: task,
+                type: "REMOVE",
+                updated: new Date(),
+            })
             rerender(task.column);
         });
     }
@@ -68,6 +73,11 @@ export default function TaskController(state, rerender) {
         const newTask = { ...task, title: newTitle, content: newContent };
     
         state.updateTask(task.column, task, newTask);
+        logStore.addLog({
+            task: task,
+            type: "UPDATE",
+            updated: new Date(),
+        });
 
         const newTaskElement = taskComponent.render(newTask);
 


### PR DESCRIPTION
## 주요 작업
Task 이동 애니메이션 적용,
옵저빙 패턴 적용,
Log redo, undo 시스템 구현 (ADD, REMOVE, MOVE) - UPDATE 구현 필요

## 학습 키워드
옵저빙 패턴, 기능 분리

## 고민과 해결과정
### 1. 기능 분리
- 기능을 명확하게 하기 위해서 기존에 Column의 task 개수 변화시 Header Rerender 함수를 renderColumn과 분리되어 있는 것을 renderColumn에서 현재 Task의 개수와 생성되어야할 Task의 개수를 비교하여 rerenderHeader를 진행할 수 있도록 기능 분리

### 2. insertBefore 사용
- 기존에 Dummy Task(잔상)을 항상 Column의 마지막 위치에 삽입하던 것을 미리 Task가 렌더링 될 위치를 계산하여 InsertBefore로 잔상을 올바른 위치에 생성되도록 적용

### 3. Container Drop 이벤트 적용
- Drop 이벤트가 일어나는 리스트 Element 밖에다가 drop을 하게 되는 경우, Task Element가 투명상태에서 해제되지 않던 문제를 Container Element에도 Drop 이벤트를 적용시켜 문제를 해결
- 이 과정에서 리스트 Element에서 drop시, event가 bubbling 되는 것을 방지하기 위해 event.stopPropagation을 사용하여 상위 컴포넌트로 이벤트 버블링을 방지

### 4. 옵저빙 패턴 및 기능 분리
- 오늘 강의에서 배운 옵저빙 패턴을 현재 내가 관리하는 State 모델에서 Log를 분리하고자 했다.
- 옵저빙 패턴에서 Store의 중요 속성 중 하나인 순수함을 달성하고자 Log의 state 및 메소드 들을 LogStore로 분리하였다.
- 로그가 바뀜에 따라 재렌더링이 필요한 로그 레이어 컴포넌트 생성 시, LogStore를 구독하여 다른 Controller에서 method로 로그를 수정 시, 구독시켰던 rerender 함수를 실행시켜, 로그 컴포넌트를 리렌더링 시켰다.
- 이전에는 로그 창을 띄워놓고 다른 행동을 취해도 로그 컴포넌트가 리렌더링이 일어나지 않았지만, 옵저빙 패턴으로 rerender함수를 구독시켜 리렌더링에 성공할 수 있었다.
```
    addLog(log) {
        this.#logPointer = 0;
        this.#logs.push({...log, logId: this.#logId});
        this.#logId++;
        this.notify(this.#logs);
    }

    clearLog() {
        this.#logs = [];
        this.notify(this.#logs);
    }

...
  export function LogComponent(columns, store, handleClear) {
      store.subscribe(rerender);
      ...
   }

```
- 다음과 같이 state가 변하는 경우에 notify를 하여 log컴포넌트를 리렌더링 할 수 있다.

- 또한, 리렌더링이 일어날 때마다, 변하지 않는 컴포넌트 또한 재생성이 되는 것을 방지하고자 정적 컴포넌트는 컴포넌트 생성 시, 처음 생성하고 closure로 관리하여 재사용할 수 있도록 하였다.
```
    export function LogComponent(columns, store, handleClear) {
        store.subscribe(rerender);
        const emptyElement = renderEmpty();
        const footerElement = renderFooter();
```
- 이를 통해 반복적인 엘리멘트 생성 및 이벤트 등록을 최소화할 수 있었다.

### 5. 로그 Undo, Redo
- 앞에서 분리한 LogStore를 바탕으로 화면의 fab 버튼을 눌러 로그를 undo, redo를 시키는 기능이 필요하여 현재 redo 또는 undo를 해야할 작업을 선정하는 것이 가장 큰 도전과제였다.

```
    class LogStore extends Observable {
        #logId;
        #logs;
        #logPointer
```
- 선택한 방법은 **로그 포인터** 이다. 기능에서 undo 혹은 redo 시킬 수 있는 log는 최대 5개이므로, log 배열에서 마지막 5개에 대한 정보가 필요하기에, 해당 포인터는 로그의 뒤에서부터 시작하도록 설정하였다.

```
    undo() {
        if(this.#logPointer >= this.#logs.length || this.#logPointer === 4) return undefined;
        const index = this.#logs.length -1 - this.#logPointer;
        this.#logPointer++;
        return this.#getCurrentLog(index);
    }

    redo() {
        if(this.#logPointer === 0 ) return undefined;
        this.#logPointer--;
        const index = this.#logs.length -1 - this.#logPointer;
        return this.#getCurrentLog(index);
    }
```
- 그 결과 undo 혹은 redo가 발생 될 때, 포인터를 이동시키고 이동된 위치가 가르키는 log를 반환할 수 있도록 구현하였다.
- FabController는 반환된 로그에 어떤 task인지를 참조하여 state를 변경시키고, ColumnController의 renderColumn을 실행 시켜 변경점을 redo, undo할 수 있었다.