### PR TITLE
[FE 김동영]  카드 정렬 및 카드 이동 구현

### DIFF
--- a/src/components/Card/ColumnCard.css
+++ b/src/components/Card/ColumnCard.css
@@ -56,6 +56,7 @@
 
 .card-drag-container{
     box-shadow: var(--shadow-floating);
+    opacity: 0.3;
 }
 
 .card-place-container{

--- a/src/components/Card/ColumnCard.css
+++ b/src/components/Card/ColumnCard.css
@@ -26,12 +26,13 @@
 .column-card-title{
     font: var(--display-bold14);
     color:var(--text-strong);
+    white-space: normal;
 }
 
 .column-card-content{
     font: var(--display-medium14);
     color:var(--text-default);
-
+    white-space: normal;
 }
 
 .column-card-author{

--- a/src/components/Card/ColumnCard.js
+++ b/src/components/Card/ColumnCard.js
@@ -36,6 +36,7 @@ export function ColumnCard({id,type,title,content,author,addText,closeText,check
         createCardButtons({columnCard,contentBox,type,closeText,addText,checkId,closeId})
     }
     else{
+        columnCard.draggable="true";
         contentBox.innerHTML = `
             <div class='column-card-title'>${title}</div>
             <div class='column-card-content'>${content}</div>
@@ -61,11 +62,6 @@ export function ColumnCard({id,type,title,content,author,addText,closeText,check
 
         iconBox.insertAdjacentElement('beforeend',editButton);
         iconBox.insertAdjacentElement('beforeend',deleteButton);
-        if(type === 'drag'){
-            columnCard.classList.add('card-drag-container');
-        }else if (type === 'place'){
-            columnCard.classList.add('card-place-container');
-        }
             
     }
     if (!modalInstances[id]) {
@@ -99,6 +95,18 @@ export function ColumnCard({id,type,title,content,author,addText,closeText,check
 
 
     loadCss('../src/components/Card/ColumnCard.css')
+
+
+    columnCard.addEventListener('dragstart',()=>{
+        columnCard.classList.add('card-drag-container');
+    })
+
+    columnCard.addEventListener('dragend',()=>{
+        columnCard.classList.remove('card-drag-container');
+    })
+
+    
+
     return columnCard;
 }
 
@@ -129,4 +137,5 @@ export function createCardButtons({columnCard,contentBox,type,closeText,addText,
 
     contentBox.insertAdjacentElement('afterend', buttonBox);
 }
+
 

--- a/src/components/Card/ColumnCard.js
+++ b/src/components/Card/ColumnCard.js
@@ -1,9 +1,16 @@
+import { Background } from '../../layout/Background/Background.js';
+import { PrimaryModal } from '../../observer/observer.js';
 import { loadCss } from '../../utils/loadcss.js';
 import { Button } from '../Button/Button.js';
+import { Modal } from '../Modal/Modal.js';
 
-export function ColumnCard({type,title,content,author,addText,closeText,checkId,editId,closeId,deleteId}){
+
+export const modalInstances = {};
+
+export function ColumnCard({id,type,title,content,author,addText,closeText,checkId,editId,closeId,deleteId}){
     const columnCard = document.createElement('div');
     columnCard.className = 'column-card-container';
+    columnCard.id= id;
     columnCard.innerHTML =`
         <div class='column-content-container'>
             <div class='column-content-box'></div>
@@ -61,6 +68,34 @@ export function ColumnCard({type,title,content,author,addText,closeText,checkId,
         }
             
     }
+    if (!modalInstances[id]) {
+        modalInstances[id] = new PrimaryModal();
+    }
+
+    modalInstances[id].subscribe((isOpen)=>{
+        const modal = columnCard.querySelector('.modal-container'); 
+        const background = columnCard.querySelector('.background-container'); 
+        if(isOpen){    
+        const fragment = document.createDocumentFragment()
+        const deleteModal = Modal({
+            content: '선택한 카드를 삭제할까요?',
+            checkId:'card-delete',
+            closeId:'card-delete-toggle',
+            closeText:'취소',
+            checkText:'삭제'
+        })
+
+        fragment.appendChild(Background());  
+        fragment.appendChild(deleteModal);  
+        columnCard.appendChild(fragment);
+        return
+        }else{
+            if(background)background.remove();
+            if(modal)modal.remove()            
+            return
+        }
+        
+    })
 
 
     loadCss('../src/components/Card/ColumnCard.css')

--- a/src/components/Card/ColumnCard.js
+++ b/src/components/Card/ColumnCard.js
@@ -8,7 +8,7 @@ import { Modal } from '../Modal/Modal.js';
 export const modalInstances = {};
 
 export function ColumnCard({id,type,title,content,author,addText,closeText,checkId,editId,closeId,deleteId}){
-    const columnCard = document.createElement('div');
+    const columnCard = document.createElement('li');
     columnCard.className = 'column-card-container';
     columnCard.id= id;
     columnCard.innerHTML =`

--- a/src/components/Chip/Chip.js
+++ b/src/components/Chip/Chip.js
@@ -1,15 +1,15 @@
 import { getIconSVG } from '../../utils/iconUtils.js';
 import { loadCss } from '../../utils/loadcss.js';
 
-export function Chip(iconType,iconColor,content,eventFuntion){
+export function Chip({iconType,iconColor,content,id}){
     const chip = document.createElement('button');
     chip.className = "chip-container";
+    chip.id= id;
     chip.innerHTML = getIconSVG(iconType,iconColor)
     chip.insertAdjacentHTML('beforeend', `
         <div class="chip-content">${content}</div>
     `);
     
-    chip.addEventListener('click', eventFuntion);
 
     loadCss('../src/components/chip/chip.css')
     return chip;

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -7,6 +7,11 @@
     justify-content: space-between;
 }
 
+.logo-box{
+    display: flex;
+    align-items: center;
+    gap:16px;
+}
 
 .logo{
     font: bold 24px normal;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,14 +1,26 @@
 import { loadCss } from '../../utils/loadcss.js';
+import { Chip } from '../Chip/Chip.js';
 
 export function Header(){
     const header = document.createElement('header');
     header.className = "header";
     header.innerHTML = `
-      <div class="logo">TASKIFY</div>
+      <div class='logo-box'>
+        <div class="logo">TASKIFY</div>
+      </div>
       <button class="history-btn">
         <img src="./src/assets/icons/history.svg" alt="활동기록">
       </button>
     `;
+
+    const logoBox= header.querySelector('.logo-box')
+    const sortChip =Chip({
+      iconType: 'arrow',
+      iconColor:'grayscale600',
+      content: '생성 순',
+      id:'createOrder'
+    })
+    logoBox.insertAdjacentElement('beforeend',sortChip);
 
     loadCss('../src/components/Header/Header.css')
     return header;

--- a/src/layout/Column/Column.css
+++ b/src/layout/Column/Column.css
@@ -15,3 +15,9 @@
     gap:4px;
 
 }
+
+.column-card-box{
+    display: flex;
+    flex-direction: column;
+    gap:10px;
+}

--- a/src/layout/Column/ColumnLayout.js
+++ b/src/layout/Column/ColumnLayout.js
@@ -33,29 +33,36 @@ const doneColumn = ColumnHeader({
 
     columnLayout.innerHTML=`
         <div class="column-container">
-            <div class="column-box" id="todo-column"></div>
-            <div class="column-box" id="in-progress-column"></div>
-            <div class="column-box" id="done-column"></div>
+            <div class="column-box" id="todo-column">
+                <ol class="column-card-box"></ol>
+            </div>
+            <div class="column-box" id="in-progress-column">
+                <ol class="column-card-box"></ol>
+            </div>
+            <div class="column-box" id="done-column">
+                <ol class="column-card-box"></ol>
+            </div>            
         </div>
     `;
     
      // 각 column-box에 컴포넌트를 추가
     const columnBoxes = columnLayout.querySelectorAll('.column-box');
-    columnBoxes[0].insertAdjacentElement("beforeend",todoColumn);
-    columnBoxes[1].insertAdjacentElement("beforeend",inProgressColumn);
-    columnBoxes[2].insertAdjacentElement("beforeend",doneColumn);
+    columnBoxes[0].insertAdjacentElement("afterbegin",todoColumn);
+    columnBoxes[1].insertAdjacentElement("afterbegin",inProgressColumn);
+    columnBoxes[2].insertAdjacentElement("afterbegin",doneColumn);
 
 
 
 
+    const columnCardBoxes=columnLayout.querySelectorAll('.column-card-box');
 
-    handleShowCardModel({columnBox:columnBoxes[0],model:todoModel});
-    handleShowCardModel({columnBox:columnBoxes[1],model:progressModel});
-    handleShowCardModel({columnBox:columnBoxes[2],model:doneModel});
+    handleShowCardModel({columnBox:columnCardBoxes[0],model:todoModel});
+    handleShowCardModel({columnBox:columnCardBoxes[1],model:progressModel});
+    handleShowCardModel({columnBox:columnCardBoxes[2],model:doneModel});
     
-    showCardList(columnBoxes[0],todoModel.tasks);
-    showCardList(columnBoxes[1],progressModel.tasks);
-    showCardList(columnBoxes[2],doneModel.tasks);
+    showCardList(columnCardBoxes[0],todoModel.tasks);
+    showCardList(columnCardBoxes[1],progressModel.tasks);
+    showCardList(columnCardBoxes[2],doneModel.tasks);
 
 
     loadCss('../src/layout/Column/Column.css')

--- a/src/layout/Column/ColumnLayout.js
+++ b/src/layout/Column/ColumnLayout.js
@@ -1,5 +1,5 @@
 import { ColumnHeader } from '../../components/Column/ColumnHeader.js';
-import { showCardList } from '../../utils/cardUtils.js';
+import { handleMoveCard, showCardList } from '../../utils/cardUtils.js';
 import { loadCss } from '../../utils/loadcss.js'
 
 export function ColumnLayout({todoModel,progressModel,doneModel}) {
@@ -66,7 +66,12 @@ const doneColumn = ColumnHeader({
 
 
     loadCss('../src/layout/Column/Column.css')
-    return columnLayout
+
+    columnCardBoxes.forEach((column)=>column.addEventListener("dragover", (e) => {
+        handleMoveCard({column,e});
+    }));
+
+    return columnLayout 
 }
 
 

--- a/src/observer/observer.js
+++ b/src/observer/observer.js
@@ -34,6 +34,16 @@ export class TaskModel extends Observable{
         this.notify(this.tasks); 
     }
 
+    sortTask(order) {
+        this.tasks.sort((a, b) => {
+            if (order === 'latestOrder') {
+                return a.id > b.id ? 1 : -1;
+            } else if(order === 'createOrder') {
+                return a.id < b.id ? 1 : -1;
+            }
+        });
+    }
+
 }
 
 

--- a/src/observer/observer.js
+++ b/src/observer/observer.js
@@ -26,11 +26,11 @@ export class TaskModel extends Observable{
     }
 
     deleteTask(taskId){
-        this.tasks =this.tasks.filter(item => item.id != taskId);
+        this.tasks =this.tasks.filter(item => item.id !== taskId);
         this.notify(this.tasks);
     }
     editTask(task){
-        this.tasks = this.tasks.map(item =>item.id == task.id ? { ...item, ...task } : item);
+        this.tasks = this.tasks.map(item =>item.id === task.id ? { ...item, ...task } : item);
         this.notify(this.tasks); 
     }
 

--- a/src/observer/observer.js
+++ b/src/observer/observer.js
@@ -30,9 +30,7 @@ export class TaskModel extends Observable{
         this.notify(this.tasks);
     }
     editTask(task){
-        this.tasks = this.tasks.map(item =>
-            item.id === task.id ? { ...item, ...task } : item
-        ); 
+        this.tasks = this.tasks.map(item =>item.id == task.id ? { ...item, ...task } : item);
         this.notify(this.tasks); 
     }
 

--- a/src/observer/observer.js
+++ b/src/observer/observer.js
@@ -21,12 +21,12 @@ export class TaskModel extends Observable{
     }
 
     addTask(task) {
-        this.tasks = [...this.tasks, task];
+        this.tasks = [task,...this.tasks];
         this.notify(this.tasks); 
     }
 
-    deleteTask(task){
-        this.tasks = this.tasks.filter(item => item.id !== task.id);
+    deleteTask(taskId){
+        this.tasks =this.tasks.filter(item => item.id != taskId);
         this.notify(this.tasks);
     }
     editTask(task){
@@ -34,6 +34,20 @@ export class TaskModel extends Observable{
             item.id === task.id ? { ...item, ...task } : item
         ); 
         this.notify(this.tasks); 
+    }
+
+}
+
+
+export class PrimaryModal extends Observable {
+    constructor() {
+        super();
+        this.isOpen = false; 
+    }
+
+    toggle() {
+        this.isOpen = !this.isOpen;
+        this.notify(this.isOpen);
     }
 
 }

--- a/src/utils/cardUtils.js
+++ b/src/utils/cardUtils.js
@@ -77,7 +77,6 @@ export function addCard({titleInput,contentInput,addForm,columnName,tasksData}){
 export function deleteCardToggle({columnCard}){
     const cardId=columnCard.id
     modalInstances[cardId].toggle()
-
     return;
 
 }
@@ -90,19 +89,21 @@ export function deleteCard({columnCard,columnName,tasksData}){
     const newData = {...tasksData,[columnSort]:model.tasks}
     localStorage.setItem('tasks',JSON.stringify(newData)) ;  
 
-
     modalInstances[cardId].toggle()
 }
 
 
 let originalTitle = ''; 
 let originalContent = '';  
+let cardId = ''
 
 export function editCardToggle({editForm,columnCard}){
     if(!editForm){
+        cardId  =columnCard.id
         originalTitle = columnCard.querySelector('.column-card-title').textContent;
         originalContent = columnCard.querySelector('.column-card-content').textContent;
         const newForm = ColumnCard({
+            id:cardId,
             type: "edit-card",
             title:originalTitle,
             content:originalContent,
@@ -115,6 +116,7 @@ export function editCardToggle({editForm,columnCard}){
         columnCard.remove()  
     }else{
         const restoredCard = ColumnCard({
+            id : cardId,
             title:originalTitle,
             content:originalContent,
             author: "author by web",
@@ -127,19 +129,27 @@ export function editCardToggle({editForm,columnCard}){
     return;
 }
 
-export function editCard({editForm}){
+export function editCard({editForm,columnName,tasksData}){
     if(editForm){
         const newTitle = editForm.querySelector('#card-title').value;
         const newContent = editForm.querySelector('#card-content').value;
-        const newForm = ColumnCard({
+        const editCard = {
+            id : cardId,
             title:newTitle,
             content:newContent,
             author: "author by web",
             editId: "card-edit-toggle",
             deleteId: "card-delete-toggle",
-        });
-        editForm.insertAdjacentElement('afterend',newForm);
-        editForm.remove()  
+        
+        }
+    
+        const [model, columnSort] = handleColumn(columnName);
+        model.editTask(editCard);
+        
+        const newData = {...tasksData,[columnSort]:model.tasks}
+        localStorage.setItem('tasks',JSON.stringify(newData)) ; 
+
+        
     }
 }
 

--- a/src/utils/cardUtils.js
+++ b/src/utils/cardUtils.js
@@ -1,13 +1,18 @@
 
-import { ColumnCard } from '../components/Card/ColumnCard.js';
-import { Modal } from '../components/Modal/Modal.js';
-import { Background } from '../layout/Background/Background.js';
-import { doneModel, progressModel, todoModel } from './mockup.js';
+import { ColumnCard, modalInstances } from '../components/Card/ColumnCard.js';
+import {  doneModel, progressModel, todoModel } from './mockup.js';
 
 export function showCardList(element,cardList){
+
+    //여기서 추가를하는게 아니라 삭제를 해야함 그걸 어떻게 해야할지 고민 
+    while (element.children.length > 1) {
+        element.removeChild(element.lastChild);
+    }
+
     const fragment = document.createDocumentFragment();
     cardList.map((item)=>{
         fragment.appendChild(ColumnCard({
+            id : item.id,
             title:item.title,
             type: item.type,
             content: item.content,
@@ -50,6 +55,7 @@ export function addCard({titleInput,contentInput,addForm,columnName,tasksData}){
     if (title && content) {
         addForm.remove()
         const newTodo ={
+            id:Date.now(),
             title,
             content ,
             author:"author by web" ,                
@@ -68,33 +74,24 @@ export function addCard({titleInput,contentInput,addForm,columnName,tasksData}){
 
 }
 
-export function deleteCardToggle({app,columnCard}){
-    const background =app.querySelector('.background-container');
-        if(!background){
-            const fragment = document.createDocumentFragment()
-            const deleteModal = Modal({
-                content: '선택한 카드를 삭제할까요?',
-                checkId:'card-delete',
-                closeId:'card-delete-toggle',
-                closeText:'취소',
-                checkText:'삭제'
-            })
+export function deleteCardToggle({columnCard}){
+    const cardId=columnCard.id
+    modalInstances[cardId].toggle()
 
-            fragment.appendChild(Background());  
-            fragment.appendChild(deleteModal);  
-            columnCard.appendChild(fragment);
-        }
-        else{
-            const modal = columnCard.querySelector('.modal-container'); 
-            background.remove();
-            modal.remove();
-        }
-        return;
-    
+    return;
+
 }
 
-export function deleteCard({columnCard}){
-    columnCard.remove();
+export function deleteCard({columnCard,columnName,tasksData}){
+    const cardId=columnCard.id
+    const [model, columnSort] = handleColumn(columnName);
+    model.deleteTask(cardId)
+        
+    const newData = {...tasksData,[columnSort]:model.tasks}
+    localStorage.setItem('tasks',JSON.stringify(newData)) ;  
+
+
+    modalInstances[cardId].toggle()
 }
 
 

--- a/src/utils/cardUtils.js
+++ b/src/utils/cardUtils.js
@@ -234,3 +234,41 @@ export function sortDataById(data,type) {
 
     return sortedData;
 }
+
+export function handleMoveCard({e,column}){
+    e.preventDefault();
+    const afterElement = getDragAfterElement(column, e.clientX, e.clientY);
+    const draggable = document.querySelector(".card-drag-container");
+
+    if (afterElement === undefined) {
+        column.appendChild(draggable);
+
+    } else {
+        column.insertBefore(draggable, afterElement);
+    }
+}
+
+
+
+export function getDragAfterElement(column,x,y) {
+    const draggableElements = [
+      ...column.querySelectorAll(".column-card-container:not(.card-drag-container)"),
+    ];
+
+    return draggableElements.reduce(
+      (closest, child) => {
+        const box = child.getBoundingClientRect();
+        const offsetX = x - box.left - box.width / 2;
+        const offsetY =y - box.top - box.height/2
+      
+        const distance = Math.abs(offsetX) + Math.abs(offsetY); // X축과 Y축의 차이를 합산하여 최단 거리 계산
+
+      if (distance < closest.distance) { // 가장 가까운 요소를 찾음
+        return { distance, element: child };
+      } else {
+        return closest;
+      }
+    },
+    { distance: Number.POSITIVE_INFINITY } // 초기값을 매우 큰 값으로 설정
+    ).element;
+}

--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -71,7 +71,7 @@ export function handleEventListener(e) {
     }
 
     else if (target.closest('#card-edit')) {
-        editCard({editForm});
+        editCard({editForm,columnName,tasksData});
         return;
     }
 }

--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -56,12 +56,12 @@ export function handleEventListener(e) {
         return;
     }
     else if (target.closest('#card-delete-toggle')) {
-        deleteCardToggle({app,columnCard});
+        deleteCardToggle({columnCard});
         return;
     }
 
     else if (target.closest('#card-delete')) {
-        deleteCard({columnCard});
+        deleteCard({columnCard,columnName,tasksData});
         return;
     }
 

--- a/src/utils/eventUtils.js
+++ b/src/utils/eventUtils.js
@@ -1,4 +1,4 @@
-import { addCard, addCardToggle, deleteCard, deleteCardToggle, editCard, editCardToggle } from './cardUtils.js';
+import { addCard, addCardToggle, createOrder, deleteCard, deleteCardToggle, editCard, editCardToggle, latestOrder } from './cardUtils.js';
 import { loadLocalStorage } from './mockup.js';
 
 
@@ -9,23 +9,26 @@ export function handleEventListener(e) {
     const target = e.target;
     // 각각의 Column
     const parentColumn = target.closest('.column-box');
+    const cardColumn = parentColumn?.querySelector('.column-card-box');
+
     // 각 컬럼의 이름
-    const columnName = parentColumn.id
+    const columnName = parentColumn?.id || ' ';
 
     // 컬럼의 header
-    const headerColumn =parentColumn.querySelector('.column-header')
+    const headerColumn =parentColumn?.querySelector('.column-header')
     
     // card 
     const columnCard= target.closest('.column-card-container');
     // 카드 추가 card
-    const addForm = parentColumn.querySelector("#add-card");
+    const addForm = parentColumn?.querySelector("#add-card");
     // 카드 추가 title
-    const titleInput = parentColumn.querySelector("#card-title");
+    const titleInput = parentColumn?.querySelector("#card-title");
     // 카드 추가 content
-    const contentInput = parentColumn.querySelector("#card-content");
+    const contentInput = parentColumn?.querySelector("#card-content");
     // 카드 수정 card
-    const editForm =parentColumn.querySelector("#edit-card")
-
+    const editForm =parentColumn?.querySelector("#edit-card")
+    // chip 
+    const  chipContainer =target.closest('.chip-container')
 
 
     const tasksData = loadLocalStorage()
@@ -43,7 +46,7 @@ export function handleEventListener(e) {
     }
 
     else if (target.closest('#card-add-toggle')) {    
-        addCardToggle({addForm,headerColumn});
+        addCardToggle({addForm,cardColumn});
         return;
     }
 
@@ -52,7 +55,7 @@ export function handleEventListener(e) {
     }
 
     else if (target.closest('#card-add')) {
-        addCard({titleInput,contentInput,addForm,headerColumn,columnName,tasksData});
+        addCard({titleInput,contentInput,addForm,columnName,tasksData});
         return;
     }
     else if (target.closest('#card-delete-toggle')) {
@@ -72,6 +75,14 @@ export function handleEventListener(e) {
 
     else if (target.closest('#card-edit')) {
         editCard({editForm,columnName,tasksData});
+        return;
+    }
+    else if (target.closest('#createOrder')) {
+        latestOrder({chipContainer,tasksData});
+        return;
+    }
+    else if (target.closest('#latestOrder')) {
+        createOrder({chipContainer,tasksData});
         return;
     }
 }


### PR DESCRIPTION
## 주요 작업
카드 정렬 및 카드 이동 구현

## 학습 키워드

## 고민과 해결과정

### 첫 번째 고민에 대한 과정 
카드 삭제를 할때 모달을 띄워야하는데 이 부분을 DOM을 조작하는 메서드와 상태를 조작하는 메서드를 분리하고 싶어서 옵저버 패턴을 적용했습니다. 
하지만 지금 다시 생각해보니 옵저버패턴은 스토어의 변경을 감지하여 구독한 요소들에게 변경되었다고 알려주는 목적인데 모달은 스토어의 변경을 감지하여 공유하는것이 목적이 아니라 옵저버 패턴을 사용하는것은 잘못된 방법인거 같습니다. DOM을 조작하는 메서드와 상태를 조작하는 메서드를 분리하려다보니 잘못된 방향으로 가게된거 같습니다. 


### 두번 째 고민에 대한 과정
카드정렬을 했을때 애니메이션을 넣어야 하기 때문에 직접적인 DOM조작이 필요한데 만약 카드정렬을 통해 데이터의 순서가 바뀌게 되면
상태값이 바뀌게 되는데 해당하는 모델에서 스토어가 변경되었다고 구독자들에게 알려줘야할까?


### 두번째 고민에 대한 생각한 방법
- 만약 스토어가 변경되었다고 알려주게 되면 notify()를 통해 showCardList에서도 다시 렌더링 하기때문에 애니메이션이 없어져서 원하는 상황이 나타나지 않는다. 
- 하지만 데이터가 변경된것인데 해당하는 구독자들에게 알려주지 않으면 데이터 동기화 측면에서 문제가 생길 수 있지 않을까?라는 생각을 했습니다. 
- 그렇다면 옵저버에서 해당 스토어의 변경만 반영 해놓고 구독한 메서드를 실행하지 않기 위해 notify() 하지 않고
   기존 저장소인 localStorage에만 반영해 놓는 방법을 선택했습니다.
   옵저버 패턴에 어긋나는 행동인거 같아서 껄끄럽지만 가장 나은 방법이라고 생각했습니다. 다른 방법이 있을지 궁금합니다. 



   


