### PR TITLE
[박규한] - 옵저버 패턴 추가 적용 및 칼럼 추가/수정/삭제 기능 구현

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -14,11 +14,16 @@ const Main = (todoList) => {
 
 export default Main;
 
-todoStore.subscribe((action, { newColumn }) => {
+todoStore.subscribe((action, { newColumn, todoList }) => {
   if (action === ACTION_TYPE.columnAdd) {
     const $main = document.querySelector(".column__main");
 
     $main.appendChild(ColumnSection(newColumn));
     $main.scrollTo({ left: $main.scrollWidth, behavior: "smooth" });
+  } else if (action === ACTION_TYPE.columnDelete) {
+    const $main = document.querySelector(".column__main");
+
+    const $columnSectionList = todoList?.map((todo) => ColumnSection(todo));
+    $main.replaceChildren(...$columnSectionList);
   }
 });

--- a/Main.js
+++ b/Main.js
@@ -1,24 +1,24 @@
 import ColumnSection from "./components/ColumnSection/ColumnSection.js";
-import { createButton, createElement, createPlusSvg } from "./dom.js";
+import { ACTION_TYPE } from "./constants/action.js";
+import { createElement } from "./dom.js";
+import todoStore from "./store/TodoStore.js";
 
 const Main = (todoList) => {
-  const $main = createElement("main", { className: "column__section" });
-
-  const $columnAddButton = createButton({
-    className: "floating__button shadow-up",
-  });
-  const $plusSvg = createPlusSvg({
-    width: "32",
-    height: "32",
-    viewBox: "0 0 24 24",
-  });
-
-  $columnAddButton.appendChild($plusSvg);
+  const $main = createElement("main", { className: "column__main" });
 
   const $columnSectionList = todoList?.map((todo) => ColumnSection(todo));
 
-  $main.append(...$columnSectionList, $columnAddButton);
+  $main.append(...$columnSectionList);
   return $main;
 };
 
 export default Main;
+
+todoStore.subscribe((action, { newColumn }) => {
+  if (action === ACTION_TYPE.columnAdd) {
+    const $main = document.querySelector(".column__main");
+
+    $main.appendChild(ColumnSection(newColumn));
+    $main.scrollTo({ left: $main.scrollWidth, behavior: "smooth" });
+  }
+});

--- a/Main.js
+++ b/Main.js
@@ -18,24 +18,30 @@ export default Main;
 todoStore.subscribe(
   (action, { newColumn, todoList, sectionId, columnTitle }) => {
     const $main = document.querySelector(".column__main");
-    if (action === ACTION_TYPE.columnAdd) {
-      $main.appendChild(ColumnSection(newColumn));
-      $main.scrollTo({ left: $main.scrollWidth, behavior: "smooth" });
-    } else if (action === ACTION_TYPE.columnDelete) {
-      const $columnSectionList = todoList?.map((todo) => ColumnSection(todo));
 
-      $main.replaceChildren(...$columnSectionList);
-    } else if (action === ACTION_TYPE.columnUpdate) {
-      const $titleContainer = $main.querySelector(
-        `#${sectionId} .column__header__titleContainer`
-      );
-      const count = $titleContainer.lastElementChild.textContent;
+    switch (action) {
+      case ACTION_TYPE.columnAdd:
+        $main.appendChild(ColumnSection(newColumn));
+        $main.scrollTo({ left: $main.scrollWidth, behavior: "smooth" });
+        break;
 
-      const $newTitleContainer = createTitleContainer({
-        title: columnTitle,
-        count,
-      });
-      $titleContainer.replaceWith($newTitleContainer);
+      case ACTION_TYPE.columnDelete:
+        const $columnSectionList = todoList?.map((todo) => ColumnSection(todo));
+        $main.replaceChildren(...$columnSectionList);
+        break;
+
+      case ACTION_TYPE.columnUpdate:
+        const $titleContainer = $main.querySelector(
+          `#${sectionId} .column__header__titleContainer`
+        );
+        const count = $titleContainer.lastElementChild.textContent;
+
+        const $newTitleContainer = createTitleContainer({
+          title: columnTitle,
+          count,
+        });
+        $titleContainer.replaceWith($newTitleContainer);
+        break;
     }
   }
 );

--- a/Main.js
+++ b/Main.js
@@ -1,13 +1,23 @@
 import ColumnSection from "./components/ColumnSection/ColumnSection.js";
-import { createElement } from "./dom.js";
+import { createButton, createElement, createPlusSvg } from "./dom.js";
 
 const Main = (todoList) => {
   const $main = createElement("main", { className: "column__section" });
 
-  todoList?.forEach((todo) => {
-    $main.appendChild(ColumnSection(todo));
+  const $columnAddButton = createButton({
+    className: "floating__button shadow-up",
+  });
+  const $plusSvg = createPlusSvg({
+    width: "32",
+    height: "32",
+    viewBox: "0 0 24 24",
   });
 
+  $columnAddButton.appendChild($plusSvg);
+
+  const $columnSectionList = todoList?.map((todo) => ColumnSection(todo));
+
+  $main.append(...$columnSectionList, $columnAddButton);
   return $main;
 };
 

--- a/Main.js
+++ b/Main.js
@@ -1,3 +1,4 @@
+import createTitleContainer from "./components/ColumnSection/ColumnHeader/ui/createTitleContainer.js";
 import ColumnSection from "./components/ColumnSection/ColumnSection.js";
 import { ACTION_TYPE } from "./constants/action.js";
 import { createElement } from "./dom.js";
@@ -14,16 +15,27 @@ const Main = (todoList) => {
 
 export default Main;
 
-todoStore.subscribe((action, { newColumn, todoList }) => {
-  if (action === ACTION_TYPE.columnAdd) {
+todoStore.subscribe(
+  (action, { newColumn, todoList, sectionId, columnTitle }) => {
     const $main = document.querySelector(".column__main");
+    if (action === ACTION_TYPE.columnAdd) {
+      $main.appendChild(ColumnSection(newColumn));
+      $main.scrollTo({ left: $main.scrollWidth, behavior: "smooth" });
+    } else if (action === ACTION_TYPE.columnDelete) {
+      const $columnSectionList = todoList?.map((todo) => ColumnSection(todo));
 
-    $main.appendChild(ColumnSection(newColumn));
-    $main.scrollTo({ left: $main.scrollWidth, behavior: "smooth" });
-  } else if (action === ACTION_TYPE.columnDelete) {
-    const $main = document.querySelector(".column__main");
+      $main.replaceChildren(...$columnSectionList);
+    } else if (action === ACTION_TYPE.columnUpdate) {
+      const $titleContainer = $main.querySelector(
+        `#${sectionId} .column__header__titleContainer`
+      );
+      const count = $titleContainer.lastElementChild.textContent;
 
-    const $columnSectionList = todoList?.map((todo) => ColumnSection(todo));
-    $main.replaceChildren(...$columnSectionList);
+      const $newTitleContainer = createTitleContainer({
+        title: columnTitle,
+        count,
+      });
+      $titleContainer.replaceWith($newTitleContainer);
+    }
   }
-});
+);

--- a/components/ColumnAddButton/ColumnAddButton.js
+++ b/components/ColumnAddButton/ColumnAddButton.js
@@ -1,0 +1,17 @@
+import { createButton, createPlusSvg } from "../../dom.js";
+
+const ColumnAddButton = () => {
+  const $columnAddButton = createButton({
+    className: "floating__button shadow-up",
+  });
+  const $plusSvg = createPlusSvg({
+    width: "32",
+    height: "32",
+    viewBox: "0 0 24 24",
+  });
+
+  $columnAddButton.appendChild($plusSvg);
+  return $columnAddButton;
+};
+
+export default ColumnAddButton;

--- a/components/ColumnInputItem/ColumnInputItem.js
+++ b/components/ColumnInputItem/ColumnInputItem.js
@@ -1,9 +1,15 @@
+import { ACTION_TYPE } from "../../constants/action.js";
 import loadStyleSheet from "../../utils/loadStyleSheet.js";
 import createColumnInputItem from "./ui/createColumnInputItem.js";
 
 loadStyleSheet("/components/ColumnInputItem/styles.css");
 
-const ColumnInputItem = ({ id, title = "", content = "", type = "add" }) => {
+const ColumnInputItem = ({
+  id,
+  title = "",
+  content = "",
+  type = ACTION_TYPE.add,
+}) => {
   return createColumnInputItem({
     id,
     title,

--- a/components/ColumnInputItem/ui/createAddButtonContainer.js
+++ b/components/ColumnInputItem/ui/createAddButtonContainer.js
@@ -1,6 +1,7 @@
+import { ACTION_TYPE } from "../../../constants/action.js";
 import { createButton, createElement } from "../../../dom.js";
 
-const createAddButtonContainer = ({ type = "add" }) => {
+const createAddButtonContainer = ({ type = ACTION_TYPE.add }) => {
   const $addButtonContainer = createElement("div", {
     className: "column__item__addButtonContainer",
   });
@@ -13,7 +14,7 @@ const createAddButtonContainer = ({ type = "add" }) => {
 
   const $submitButton = createButton({
     className: "submit__button",
-    text: type === "add" ? "등록" : "저장",
+    text: type === ACTION_TYPE.add ? "등록" : "저장",
     disabled: true,
     type,
   });

--- a/components/ColumnInputItem/ui/createColumnInputItem.js
+++ b/components/ColumnInputItem/ui/createColumnInputItem.js
@@ -1,3 +1,4 @@
+import { ACTION_TYPE } from "../../../constants/action.js";
 import { createElement } from "../../../dom.js";
 import createAddButtonContainer from "./createAddButtonContainer.js";
 import createInputContainer from "./createInputContainer.js";
@@ -6,7 +7,7 @@ const createColumnInputItem = ({
   id,
   title = "",
   content = "",
-  type = "add",
+  type = ACTION_TYPE.add,
 }) => {
   const $columnInputItem = createElement("div", {
     className: "column__item",

--- a/components/ColumnItem/ColumnItem.js
+++ b/components/ColumnItem/ColumnItem.js
@@ -1,3 +1,4 @@
+import { ACTION_TYPE } from "../../constants/action.js";
 import todoStore from "../../store/TodoStore.js";
 import loadStyleSheet from "../../utils/loadStyleSheet.js";
 import createColumnItem from "./ui/createColumnItem.js";
@@ -15,28 +16,36 @@ const ColumnItem = ({ id, title = "", content = "", author = "web" }) => {
   return $columnItem;
 };
 
-todoStore.subscribe((action, { sectionId, newTodo, deletedId, todoList }) => {
-  const $columnBody = document.querySelector(`#${sectionId} .column__body`);
+todoStore.subscribe(
+  (action, { sectionId, newTodo, deletedId, updatedTodo, todoList }) => {
+    const $columnBody = document.querySelector(`#${sectionId} .column__body`);
 
-  if (action === "add") {
-    $columnBody.replaceChild(
-      ColumnItem({ ...newTodo }),
-      $columnBody.firstChild
-    );
-  } else if (action === "remove") {
-    const $columnItem = document.querySelector(
-      `.column__item[data-id="${deletedId}"]`
-    );
+    if (action === ACTION_TYPE.add) {
+      $columnBody.replaceChild(
+        ColumnItem({ ...newTodo }),
+        $columnBody.firstChild
+      );
+    } else if (action === ACTION_TYPE.remove) {
+      const $columnItem = document.querySelector(
+        `.column__item[data-id="${deletedId}"]`
+      );
 
-    $columnItem.remove();
+      $columnItem.remove();
+    } else if (action === ACTION_TYPE.update) {
+      const $columnItem = document.querySelector(
+        `.column__item[data-id="${updatedTodo.id}"]`
+      );
+
+      $columnItem.replaceWith(ColumnItem({ ...updatedTodo }));
+    }
+
+    updateCount({
+      $columnBody,
+      newTodoList: todoList,
+      sectionId,
+    });
   }
-
-  updateCount({
-    $columnBody,
-    newTodoList: todoList,
-    sectionId,
-  });
-});
+);
 
 const updateCount = ({ $columnBody, newTodoList, sectionId }) => {
   const itemLength = newTodoList.find((section) => section.id === sectionId)

--- a/components/ColumnItem/ColumnItem.js
+++ b/components/ColumnItem/ColumnItem.js
@@ -20,6 +20,12 @@ todoStore.subscribe(
   (action, { sectionId, newTodo, deletedId, updatedTodo, todoList }) => {
     const $columnBody = document.querySelector(`#${sectionId} .column__body`);
 
+    if (action === ACTION_TYPE.move) {
+      updateColumnCountAll(todoList);
+
+      return;
+    }
+
     if (action === ACTION_TYPE.add) {
       $columnBody.replaceChild(
         ColumnItem({ ...newTodo }),
@@ -56,6 +62,18 @@ const updateCount = ({ $columnBody, newTodoList, sectionId }) => {
     .querySelector(".column__count");
 
   $columnCount.textContent = itemLength;
+};
+
+const updateColumnCountAll = (newTodoList) => {
+  const $columnSection = document.querySelector(".column__section");
+
+  newTodoList.forEach(({ id, items }) => {
+    const $count = $columnSection
+      .querySelector(`#${id}`)
+      .querySelector(".column__count");
+
+    $count.textContent = items.length;
+  });
 };
 
 export default ColumnItem;

--- a/components/ColumnItem/ColumnItem.js
+++ b/components/ColumnItem/ColumnItem.js
@@ -1,5 +1,3 @@
-import { ACTION_TYPE } from "../../constants/action.js";
-import todoStore from "../../store/TodoStore.js";
 import loadStyleSheet from "../../utils/loadStyleSheet.js";
 import createColumnItem from "./ui/createColumnItem.js";
 
@@ -14,66 +12,6 @@ const ColumnItem = ({ id, title = "", content = "", author = "web" }) => {
   });
 
   return $columnItem;
-};
-
-todoStore.subscribe(
-  (action, { sectionId, newTodo, deletedId, updatedTodo, todoList }) => {
-    const $columnBody = document.querySelector(`#${sectionId} .column__body`);
-
-    if (action === ACTION_TYPE.move) {
-      updateColumnCountAll(todoList);
-
-      return;
-    }
-
-    if (action === ACTION_TYPE.add) {
-      $columnBody.replaceChild(
-        ColumnItem({ ...newTodo }),
-        $columnBody.firstChild
-      );
-    } else if (action === ACTION_TYPE.remove) {
-      const $columnItem = document.querySelector(
-        `.column__item[data-id="${deletedId}"]`
-      );
-
-      $columnItem.remove();
-    } else if (action === ACTION_TYPE.update) {
-      const $columnItem = document.querySelector(
-        `.column__item[data-id="${updatedTodo.id}"]`
-      );
-
-      $columnItem.replaceWith(ColumnItem({ ...updatedTodo }));
-    }
-
-    updateCount({
-      $columnBody,
-      newTodoList: todoList,
-      sectionId,
-    });
-  }
-);
-
-const updateCount = ({ $columnBody, newTodoList, sectionId }) => {
-  const itemLength = newTodoList.find((section) => section.id === sectionId)
-    .items.length;
-
-  const $columnCount = $columnBody
-    .closest(".column__container")
-    .querySelector(".column__count");
-
-  $columnCount.textContent = itemLength;
-};
-
-const updateColumnCountAll = (newTodoList) => {
-  const $columnSection = document.querySelector(".column__section");
-
-  newTodoList.forEach(({ id, items }) => {
-    const $count = $columnSection
-      .querySelector(`#${id}`)
-      .querySelector(".column__count");
-
-    $count.textContent = items.length;
-  });
 };
 
 export default ColumnItem;

--- a/components/ColumnSection/ColumnBody/ColumnBody.js
+++ b/components/ColumnSection/ColumnBody/ColumnBody.js
@@ -32,25 +32,37 @@ todoStore.subscribe(
         ColumnItem({ ...newTodo }),
         $columnBody.firstChild
       );
+
+      updateCount({
+        $columnBody,
+        newTodoList: todoList,
+        sectionId,
+      });
     } else if (action === ACTION_TYPE.remove) {
       const $columnItem = document.querySelector(
         `.column__item[data-id="${deletedId}"]`
       );
 
       $columnItem.remove();
+
+      updateCount({
+        $columnBody,
+        newTodoList: todoList,
+        sectionId,
+      });
     } else if (action === ACTION_TYPE.update) {
       const $columnItem = document.querySelector(
         `.column__item[data-id="${updatedTodo.id}"]`
       );
 
       $columnItem.replaceWith(ColumnItem({ ...updatedTodo }));
-    }
 
-    updateCount({
-      $columnBody,
-      newTodoList: todoList,
-      sectionId,
-    });
+      updateCount({
+        $columnBody,
+        newTodoList: todoList,
+        sectionId,
+      });
+    }
   }
 );
 
@@ -66,10 +78,10 @@ const updateCount = ({ $columnBody, newTodoList, sectionId }) => {
 };
 
 const updateColumnCountAll = (newTodoList) => {
-  const $columnSection = document.querySelector(".column__section");
+  const $columnMain = document.querySelector(".column__main");
 
   newTodoList.forEach(({ id, items }) => {
-    const $count = $columnSection
+    const $count = $columnMain
       .querySelector(`#${id}`)
       .querySelector(".column__count");
 

--- a/components/ColumnSection/ColumnBody/ColumnBody.js
+++ b/components/ColumnSection/ColumnBody/ColumnBody.js
@@ -21,47 +21,51 @@ todoStore.subscribe(
   (action, { sectionId, newTodo, deletedId, updatedTodo, todoList }) => {
     const $columnBody = document.querySelector(`#${sectionId} .column__body`);
 
-    if (action === ACTION_TYPE.move) {
-      updateColumnCountAll(todoList);
+    switch (action) {
+      case ACTION_TYPE.move:
+        updateColumnCountAll(todoList);
+        return;
 
-      return;
-    }
+      case ACTION_TYPE.add:
+        $columnBody.replaceChild(
+          ColumnItem({ ...newTodo }),
+          $columnBody.firstChild
+        );
 
-    if (action === ACTION_TYPE.add) {
-      $columnBody.replaceChild(
-        ColumnItem({ ...newTodo }),
-        $columnBody.firstChild
-      );
+        updateCount({
+          $columnBody,
+          newTodoList: todoList,
+          sectionId,
+        });
+        break;
 
-      updateCount({
-        $columnBody,
-        newTodoList: todoList,
-        sectionId,
-      });
-    } else if (action === ACTION_TYPE.remove) {
-      const $columnItem = document.querySelector(
-        `.column__item[data-id="${deletedId}"]`
-      );
+      case ACTION_TYPE.remove:
+        const $columnItem = document.querySelector(
+          `.column__item[data-id="${deletedId}"]`
+        );
 
-      $columnItem.remove();
+        $columnItem.remove();
 
-      updateCount({
-        $columnBody,
-        newTodoList: todoList,
-        sectionId,
-      });
-    } else if (action === ACTION_TYPE.update) {
-      const $columnItem = document.querySelector(
-        `.column__item[data-id="${updatedTodo.id}"]`
-      );
+        updateCount({
+          $columnBody,
+          newTodoList: todoList,
+          sectionId,
+        });
+        break;
 
-      $columnItem.replaceWith(ColumnItem({ ...updatedTodo }));
+      case ACTION_TYPE.update:
+        const $updatedColumnItem = document.querySelector(
+          `.column__item[data-id="${updatedTodo.id}"]`
+        );
 
-      updateCount({
-        $columnBody,
-        newTodoList: todoList,
-        sectionId,
-      });
+        $updatedColumnItem.replaceWith(ColumnItem({ ...updatedTodo }));
+
+        updateCount({
+          $columnBody,
+          newTodoList: todoList,
+          sectionId,
+        });
+        break;
     }
   }
 );

--- a/components/ColumnSection/ColumnBody/ColumnBody.js
+++ b/components/ColumnSection/ColumnBody/ColumnBody.js
@@ -1,3 +1,5 @@
+import { ACTION_TYPE } from "../../../constants/action.js";
+import todoStore from "../../../store/TodoStore.js";
 import loadStyleSheet from "../../../utils/loadStyleSheet.js";
 import createColumnBody from "./ui/createColumnBody.js";
 
@@ -13,3 +15,63 @@ const ColumnBody = ({ sectionId, items }) => {
 };
 
 export default ColumnBody;
+
+todoStore.subscribe(
+  (action, { sectionId, newTodo, deletedId, updatedTodo, todoList }) => {
+    const $columnBody = document.querySelector(`#${sectionId} .column__body`);
+
+    if (action === ACTION_TYPE.move) {
+      updateColumnCountAll(todoList);
+
+      return;
+    }
+
+    if (action === ACTION_TYPE.add) {
+      $columnBody.replaceChild(
+        ColumnItem({ ...newTodo }),
+        $columnBody.firstChild
+      );
+    } else if (action === ACTION_TYPE.remove) {
+      const $columnItem = document.querySelector(
+        `.column__item[data-id="${deletedId}"]`
+      );
+
+      $columnItem.remove();
+    } else if (action === ACTION_TYPE.update) {
+      const $columnItem = document.querySelector(
+        `.column__item[data-id="${updatedTodo.id}"]`
+      );
+
+      $columnItem.replaceWith(ColumnItem({ ...updatedTodo }));
+    }
+
+    updateCount({
+      $columnBody,
+      newTodoList: todoList,
+      sectionId,
+    });
+  }
+);
+
+const updateCount = ({ $columnBody, newTodoList, sectionId }) => {
+  const itemLength = newTodoList.find((section) => section.id === sectionId)
+    .items.length;
+
+  const $columnCount = $columnBody
+    .closest(".column__container")
+    .querySelector(".column__count");
+
+  $columnCount.textContent = itemLength;
+};
+
+const updateColumnCountAll = (newTodoList) => {
+  const $columnSection = document.querySelector(".column__section");
+
+  newTodoList.forEach(({ id, items }) => {
+    const $count = $columnSection
+      .querySelector(`#${id}`)
+      .querySelector(".column__count");
+
+    $count.textContent = items.length;
+  });
+};

--- a/components/ColumnSection/ColumnBody/ColumnBody.js
+++ b/components/ColumnSection/ColumnBody/ColumnBody.js
@@ -1,6 +1,7 @@
 import { ACTION_TYPE } from "../../../constants/action.js";
 import todoStore from "../../../store/TodoStore.js";
 import loadStyleSheet from "../../../utils/loadStyleSheet.js";
+import ColumnItem from "../../ColumnItem/ColumnItem.js";
 import createColumnBody from "./ui/createColumnBody.js";
 
 loadStyleSheet("/components/ColumnSection/ColumnBody/styles.css");

--- a/components/ColumnSection/ColumnHeader/styles.css
+++ b/components/ColumnSection/ColumnHeader/styles.css
@@ -4,6 +4,7 @@
   gap: 1.2rem;
   justify-content: space-between;
   padding: 0 1.6rem;
+  width: 32rem;
 }
 
 .column__header__titleContainer {

--- a/components/ColumnSection/ColumnHeader/styles.css
+++ b/components/ColumnSection/ColumnHeader/styles.css
@@ -11,6 +11,7 @@
   display: flex;
   align-items: center;
   gap: 0.8rem;
+  width: 100%;
 }
 
 .column__title {

--- a/components/ColumnSection/ColumnHeader/ui/createButtonContainer.js
+++ b/components/ColumnSection/ColumnHeader/ui/createButtonContainer.js
@@ -18,10 +18,11 @@ const createButtonContainer = () => {
     alt: "추가",
   });
 
-  const $closeButton = createButton({
-    handleClick: () => alert("Close button"),
+  const $deleteButton = createButton({
+    className: "column__deleteButton",
+    type: "column",
   });
-  const $closeImg = createDeleteSvg({
+  const $deleteImg = createDeleteSvg({
     className: "delete__img",
     width: "24",
     height: "24",
@@ -30,8 +31,8 @@ const createButtonContainer = () => {
   });
 
   $addButton.appendChild($addImg);
-  $closeButton.appendChild($closeImg);
-  $buttonContainer.append($addButton, $closeButton);
+  $deleteButton.appendChild($deleteImg);
+  $buttonContainer.append($addButton, $deleteButton);
 
   return $buttonContainer;
 };

--- a/components/Header/UserHistory/HistoryMain/HistoryItem/ui/createHistoryText.js
+++ b/components/Header/UserHistory/HistoryMain/HistoryItem/ui/createHistoryText.js
@@ -1,3 +1,4 @@
+import { ACTION_TYPE } from "../../../../../../constants/action.js";
 import { createElement } from "../../../../../../dom.js";
 
 const actionMapper = {
@@ -34,7 +35,7 @@ const createHistoryText = ({ history }) => {
   });
 
   switch (history.action) {
-    case "add":
+    case ACTION_TYPE.add:
       return [
         $title,
         document.createTextNode("을(를) "),
@@ -44,7 +45,7 @@ const createHistoryText = ({ history }) => {
         document.createTextNode("하였습니다."),
       ];
 
-    case "remove":
+    case ACTION_TYPE.remove:
       return [
         $title,
         document.createTextNode("을(를) "),
@@ -52,7 +53,7 @@ const createHistoryText = ({ history }) => {
         document.createTextNode("하였습니다."),
       ];
 
-    case "update":
+    case ACTION_TYPE.update:
       return [
         $title,
         document.createTextNode("을(를) "),
@@ -60,7 +61,7 @@ const createHistoryText = ({ history }) => {
         document.createTextNode("하였습니다."),
       ];
 
-    case "move":
+    case ACTION_TYPE.move:
       return [
         $title,
         document.createTextNode("을(를) "),

--- a/components/Modal/createInputModal.js
+++ b/components/Modal/createInputModal.js
@@ -1,0 +1,22 @@
+import { createElement } from "../../dom.js";
+
+const createInputModal = () => {
+  const $modalContainer = document.getElementById("modal-container");
+  const $modal = createElement("div", { id: "modal" });
+
+  $modal.innerHTML = /*html*/ `
+      <div class="modal__dimmed"></div>
+      <div class="modal modal__wrapper shadow-up">
+        <span class="modal__title display-bold16">칼럼 추가</span>
+        <input class="modal__titleInput display-medium16" placeholder="추가할 칼럼 이름을 입력하세요"/>
+        <div class="modal__buttonContainer">
+        <button class="cancel__button display-bold14">취소</button>
+          <button class="add__button display-bold14">추가</button>
+        </div>
+      </div>
+    `;
+
+  $modalContainer.appendChild($modal);
+};
+
+export default createInputModal;

--- a/components/Modal/styles.css
+++ b/components/Modal/styles.css
@@ -55,8 +55,25 @@
     background-color: var(--color-surface-brand);
     color: var(--color-text-white-default);
   }
+
+  .add__button {
+    background-color: var(--color-surface-brand);
+    color: var(--color-text-white-default);
+  }
 }
 
 .modal__wrapper textarea {
   text-align: center;
+}
+
+.modal__titleInput {
+  width: 100%;
+  padding: 0.8rem;
+  border-radius: 1.2rem;
+
+  border: 1px solid var(--color-text-weak);
+
+  ::placeholder {
+    color: var(--color-text-strong);
+  }
 }

--- a/constants/action.js
+++ b/constants/action.js
@@ -3,4 +3,5 @@ export const ACTION_TYPE = {
   remove: "remove",
   update: "update",
   move: "move",
+  columnAdd: "columnAdd",
 };

--- a/constants/action.js
+++ b/constants/action.js
@@ -4,4 +4,5 @@ export const ACTION_TYPE = {
   update: "update",
   move: "move",
   columnAdd: "columnAdd",
+  columnDelete: "columnDelete",
 };

--- a/constants/action.js
+++ b/constants/action.js
@@ -5,4 +5,5 @@ export const ACTION_TYPE = {
   move: "move",
   columnAdd: "columnAdd",
   columnDelete: "columnDelete",
+  columnUpdate: "columnUpdate",
 };

--- a/constants/action.js
+++ b/constants/action.js
@@ -1,0 +1,6 @@
+export const ACTION_TYPE = {
+  add: "add",
+  remove: "remove",
+  update: "update",
+  move: "move",
+};

--- a/dom.js
+++ b/dom.js
@@ -1,3 +1,5 @@
+import { ACTION_TYPE } from "./constants/action.js";
+
 export const createElement = (tagName, options = {}) => {
   const $element = document.createElement(tagName);
   const { id, className, text, ...attributes } = options;
@@ -22,7 +24,7 @@ export const createButton = ({
   text = "",
   handleClick,
   disabled,
-  type = "add",
+  type = ACTION_TYPE.add,
 }) => {
   const $button = createElement("button", { id, className, text });
   $button.disabled = disabled ?? false;

--- a/dom.js
+++ b/dom.js
@@ -89,3 +89,27 @@ export const createDeleteSvg = ({ className, ...props }) => {
 
   return $svg;
 };
+
+export const createPlusSvg = ({ className, ...props }) => {
+  const SVG_NS = "http://www.w3.org/2000/svg";
+
+  const $svg = document.createElementNS(SVG_NS, "svg");
+  $svg.setAttribute("xmlns", SVG_NS);
+  $svg.setAttribute("class", className);
+
+  props &&
+    Object.entries(props).forEach(([key, value]) => {
+      $svg.setAttribute(key, value);
+    });
+
+  const path = document.createElementNS(SVG_NS, "path");
+  path.setAttribute(
+    "d",
+    "M19 12.998H13V18.998H11V12.998H5V10.998H11V4.99799H13V10.998H19V12.998Z"
+  );
+  path.setAttribute("fill", "#FEFEFE");
+
+  $svg.appendChild(path);
+
+  return $svg;
+};

--- a/dom.js
+++ b/dom.js
@@ -113,3 +113,25 @@ export const createPlusSvg = ({ className, ...props }) => {
 
   return $svg;
 };
+
+export const createInput = ({
+  id = null,
+  className = null,
+  handleChange,
+  handleInput,
+  handleBlur,
+  placeholder = "",
+  maxLength = 50,
+  value = "",
+}) => {
+  const $input = createElement("input", { id, className });
+  $input.maxLength = maxLength;
+  $input.placeholder = placeholder ?? undefined;
+  $input.value = value;
+
+  $input.addEventListener("change", handleChange);
+  $input.addEventListener("input", handleInput);
+  $input.addEventListener("blur", handleBlur);
+
+  return $input;
+};

--- a/handlers/columnBody.js
+++ b/handlers/columnBody.js
@@ -51,25 +51,22 @@ export const handleDrop = (e) => {
 };
 
 const updateTodoList = ({ sectionId, itemId, prevSectionId, title }) => {
+  // 데이터 처리
   const todoList = loadLocalStorage(STORAGE_KEY.todoList);
 
-  let draggedItem = null;
+  const prevColumn = todoList.find((section) => section.id === prevSectionId);
+  const nextColumn = todoList.find((section) => section.id === sectionId);
 
-  const prevColumn = todoList.find(
-    (section) => section.id === prevSectionId
-  ).title;
-  const nextColumn = todoList.find((section) => section.id === sectionId).title;
+  const draggedItem = prevColumn.items.find((item) => item.id === itemId);
 
-  const filteredList = todoList.map((section) => {
-    if (section.items.some((item) => item.id === itemId)) {
-      draggedItem = section.items.find((item) => item.id === itemId);
-      return {
-        ...section,
-        items: section.items.filter((item) => item.id !== itemId),
-      };
-    }
-    return section;
-  });
+  const filteredList = todoList.map((section) =>
+    section.id === prevSectionId
+      ? {
+          ...section,
+          items: section.items.filter((item) => item.id !== itemId),
+        }
+      : section
+  );
 
   const finalList = filteredList.map((section) => {
     if (section.id === sectionId && draggedItem) {
@@ -81,15 +78,18 @@ const updateTodoList = ({ sectionId, itemId, prevSectionId, title }) => {
     return section;
   });
 
+  // UI 업데이트
   updateCount(finalList);
+
+  // 데이터 처리
   saveLocalStorage(STORAGE_KEY.todoList, finalList);
 
   if (prevColumn !== nextColumn) {
     historyStore.action({
       action: ACTION_TYPE.move,
       title,
-      prevColumn: prevColumn,
-      nextColumn: nextColumn,
+      prevColumn: prevColumn.title,
+      nextColumn: nextColumn.title,
     });
   }
 };

--- a/handlers/columnBody.js
+++ b/handlers/columnBody.js
@@ -1,4 +1,6 @@
+import { ACTION_TYPE } from "../constants/action.js";
 import { STORAGE_KEY } from "../constants/storageKey.js";
+import historyStore from "../store/historyStore.js";
 import { loadLocalStorage, saveLocalStorage } from "../utils/localStorage.js";
 
 export const handleDragStart = (e) => {
@@ -84,7 +86,7 @@ const updateTodoList = ({ sectionId, itemId, prevSectionId, title }) => {
 
   if (prevColumn !== nextColumn) {
     historyStore.action({
-      action: "move",
+      action: ACTION_TYPE.move,
       title,
       prevColumn: prevColumn,
       nextColumn: nextColumn,

--- a/handlers/columnHeader.js
+++ b/handlers/columnHeader.js
@@ -1,4 +1,5 @@
 import ColumnInputItem from "../components/ColumnInputItem/ColumnInputItem.js";
+import createModal from "../components/Modal/createModal.js";
 
 export const handleClickAdd = (e, store) => {
   if (store.isTodoAdding) {
@@ -27,4 +28,12 @@ const addColumnItemInput = ({ e, store }) => {
   const $columnItemInput = ColumnInputItem({ store });
   $columnBody.prepend($columnItemInput);
   store.isTodoAdding = true;
+};
+
+export const handleDeleteColumn = (e) => {
+  const sectionId = e.target.closest(".column__container").id;
+  const $modalContainer = document.getElementById("modal-container");
+  $modalContainer.dataset.sectionId = sectionId;
+
+  createModal({ content: "해당 칼럼을 삭제하시겠습니까?", type: "column" });
 };

--- a/handlers/columnHeader.js
+++ b/handlers/columnHeader.js
@@ -1,5 +1,7 @@
 import ColumnInputItem from "../components/ColumnInputItem/ColumnInputItem.js";
 import createModal from "../components/Modal/createModal.js";
+import { createInput } from "../dom.js";
+import todoStore from "../store/TodoStore.js";
 
 export const handleClickAdd = (e, store) => {
   if (store.isTodoAdding) {
@@ -36,4 +38,29 @@ export const handleDeleteColumn = (e) => {
   $modalContainer.dataset.sectionId = sectionId;
 
   createModal({ content: "해당 칼럼을 삭제하시겠습니까?", type: "column" });
+};
+
+export const handleDbClickColumnHeader = (e) => {
+  const $title = e.target.closest(".column__header__titleContainer").firstChild;
+
+  const headerInput = createInput({
+    className: "header__input display-bold16",
+    value: $title.textContent,
+  });
+  $title.replaceWith(headerInput);
+};
+
+// input 외의 영역 클릭
+export const handleClickInputOutside = () => {
+  const $headerInput = document.querySelector(".header__input");
+
+  if (!$headerInput) {
+    return;
+  }
+
+  const title = $headerInput.value;
+  const $titleContainer = $headerInput.parentElement;
+  const sectionId = $titleContainer.closest(".column__container").id;
+
+  todoStore.columnUpdate({ sectionId, title });
 };

--- a/handlers/columnItem.js
+++ b/handlers/columnItem.js
@@ -1,5 +1,6 @@
 import ColumnInputItem from "../components/ColumnInputItem/ColumnInputItem.js";
 import createModal from "../components/Modal/createModal.js";
+import { ACTION_TYPE } from "../constants/action.js";
 import historyStore from "../store/historyStore.js";
 import todoStore from "../store/TodoStore.js";
 
@@ -27,7 +28,7 @@ export const handleClickEdit = (e) => {
     id: itemId,
     title,
     content,
-    type: "edit",
+    type: ACTION_TYPE.update,
   });
 
   $columnItem.replaceWith($columnInputItem);
@@ -43,7 +44,7 @@ export const deleteColumnItem = ({ sectionId, itemId }) => {
     deletedId: deletedCard.id,
   });
   historyStore.action({
-    action: "remove",
+    action: ACTION_TYPE.remove,
     title: deletedCard.title,
   });
 };

--- a/handlers/index.js
+++ b/handlers/index.js
@@ -8,6 +8,8 @@ import {
 import {
   handleCancelAdd,
   handleClickAdd,
+  handleClickInputOutside,
+  handleDbClickColumnHeader,
   handleDeleteColumn,
 } from "./columnHeader.js";
 import {
@@ -47,6 +49,8 @@ export const addRootEventListener = () => {
     const $addColumnButton = e.target.closest(".floating__button");
     const $deleteColumnButton = e.target.closest(".column__deleteButton");
 
+    const $headerInput = e.target.closest(".header__input");
+
     if ($addButton) {
       handleClickAdd(e, store);
     } else if ($deleteHistoryButton) {
@@ -68,6 +72,18 @@ export const addRootEventListener = () => {
       handleAddColumn();
     } else if ($deleteColumnButton) {
       handleDeleteColumn(e);
+    } else if (!$headerInput) {
+      handleClickInputOutside();
+    }
+  });
+
+  $root.addEventListener("dblclick", (e) => {
+    const $columnTitleHeader = e.target.closest(
+      ".column__header__titleContainer"
+    );
+
+    if ($columnTitleHeader) {
+      handleDbClickColumnHeader(e);
     }
   });
 

--- a/handlers/index.js
+++ b/handlers/index.js
@@ -1,3 +1,4 @@
+import { ACTION_TYPE } from "../constants/action.js";
 import {
   handleDragEnd,
   handleDragOver,
@@ -42,7 +43,7 @@ export const addRootEventListener = () => {
       handleClickEdit(e);
     } else if ($closeButton) {
       const type = $closeButton.dataset.type;
-      type === "add"
+      type === ACTION_TYPE.add
         ? handleCancelAdd(e, store)
         : handleCancelEdit(e, store, type);
     } else if ($submitButton) {

--- a/handlers/index.js
+++ b/handlers/index.js
@@ -5,7 +5,11 @@ import {
   handleDragStart,
   handleDrop,
 } from "./columnBody.js";
-import { handleCancelAdd, handleClickAdd } from "./columnHeader.js";
+import {
+  handleCancelAdd,
+  handleClickAdd,
+  handleDeleteColumn,
+} from "./columnHeader.js";
 import {
   handleCancelEdit,
   handleInputContent,
@@ -15,6 +19,7 @@ import {
 import { handleClickDelete, handleClickEdit } from "./columnItem.js";
 import {
   addColumn,
+  deleteColumn,
   deleteHistory,
   handleAddColumn,
   handleClose,
@@ -40,13 +45,15 @@ export const addRootEventListener = () => {
     );
 
     const $addColumnButton = e.target.closest(".floating__button");
+    const $deleteColumnButton = e.target.closest(".column__deleteButton");
 
     if ($addButton) {
       handleClickAdd(e, store);
     } else if ($deleteHistoryButton) {
       handleClickDeleteHistory();
     } else if ($deleteButton) {
-      handleClickDelete(e);
+      const type = $deleteButton.dataset.type;
+      handleClickDelete(e, type);
     } else if ($editButton) {
       handleClickEdit(e);
     } else if ($closeButton) {
@@ -59,6 +66,8 @@ export const addRootEventListener = () => {
       handleSubmit(e, store, type);
     } else if ($addColumnButton) {
       handleAddColumn();
+    } else if ($deleteColumnButton) {
+      handleDeleteColumn(e);
     }
   });
 
@@ -124,7 +133,19 @@ export const addModalEventListener = () => {
       handleClose(e);
     } else if ($deleteButton) {
       const type = $deleteButton.dataset.type;
-      type === "card" ? handleDeleteCard(e) : deleteHistory(e);
+
+      switch (type) {
+        case "card":
+          handleDeleteCard(e);
+          break;
+        case "history":
+          deleteHistory(e);
+          break;
+
+        case "column":
+          deleteColumn(e);
+          break;
+      }
     } else if ($columnAddButton) {
       addColumn(e);
     }

--- a/handlers/index.js
+++ b/handlers/index.js
@@ -13,7 +13,13 @@ import {
   handleSubmit,
 } from "./columnInputItem.js";
 import { handleClickDelete, handleClickEdit } from "./columnItem.js";
-import { deleteHistory, handleClose, handleDeleteCard } from "./modal.js";
+import {
+  addColumn,
+  deleteHistory,
+  handleAddColumn,
+  handleClose,
+  handleDeleteCard,
+} from "./modal.js";
 import { handleClickDeleteHistory } from "./userHistory.js";
 
 const store = { isTodoAdding: false };
@@ -33,6 +39,8 @@ export const addRootEventListener = () => {
       ".history__footer .delete__button"
     );
 
+    const $addColumnButton = e.target.closest(".floating__button");
+
     if ($addButton) {
       handleClickAdd(e, store);
     } else if ($deleteHistoryButton) {
@@ -49,6 +57,8 @@ export const addRootEventListener = () => {
     } else if ($submitButton) {
       const type = $submitButton.dataset.type;
       handleSubmit(e, store, type);
+    } else if ($addColumnButton) {
+      handleAddColumn();
     }
   });
 
@@ -108,12 +118,15 @@ export const addModalEventListener = () => {
     const $dimmed = target.closest(".modal__dimmed");
     const $cancelButton = target.closest(".cancel__button");
     const $deleteButton = target.closest(".delete__button");
+    const $columnAddButton = target.closest(".add__button");
 
     if ($dimmed || $cancelButton) {
       handleClose(e);
     } else if ($deleteButton) {
       const type = $deleteButton.dataset.type;
       type === "card" ? handleDeleteCard(e) : deleteHistory(e);
+    } else if ($columnAddButton) {
+      addColumn(e);
     }
   });
 };

--- a/handlers/modal.js
+++ b/handlers/modal.js
@@ -1,4 +1,6 @@
+import createInputModal from "../components/Modal/createInputModal.js";
 import historyStore from "../store/historyStore.js";
+import todoStore from "../store/TodoStore.js";
 import { deleteColumnItem } from "./columnItem.js";
 
 export const handleClose = (e) => {
@@ -21,5 +23,22 @@ export const handleDeleteCard = (e) => {
 
 export const deleteHistory = (e) => {
   historyStore.clear();
+  handleClose(e);
+};
+
+export const handleAddColumn = () => {
+  createInputModal();
+};
+
+export const addColumn = (e) => {
+  const title = e.target
+    .closest("#modal")
+    .querySelector(".modal__titleInput")
+    .value.trim();
+
+  todoStore.columnAdd({
+    title: title ?? "새로운 칼럼",
+  });
+
   handleClose(e);
 };

--- a/handlers/modal.js
+++ b/handlers/modal.js
@@ -42,3 +42,10 @@ export const addColumn = (e) => {
 
   handleClose(e);
 };
+
+export const deleteColumn = (e) => {
+  const sectionId = e.target.closest("#modal-container").dataset.sectionId;
+
+  todoStore.columnDelete({ sectionId });
+  handleClose(e);
+};

--- a/index.js
+++ b/index.js
@@ -6,12 +6,12 @@ import {
   addModalEventListener,
   addRootEventListener,
 } from "./handlers/index.js";
+import ColumnAddButton from "./components/ColumnAddButton/ColumnAddButton.js";
 
 const todoList = initStorage(STORAGE_KEY.todoList);
 
 const $root = document.getElementById("root");
-$root.appendChild(Header());
-$root.appendChild(Main(todoList));
+$root.append(Header(), Main(todoList), ColumnAddButton());
 
 addRootEventListener();
 addModalEventListener();

--- a/store/TodoStore.js
+++ b/store/TodoStore.js
@@ -128,6 +128,15 @@ class TodoStore extends Observable {
     saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
   }
 
+  columnUpdate({ sectionId, title }) {
+    this.#todoList = this.#todoList.map((section) =>
+      section.id === sectionId ? { ...section, title } : section
+    );
+
+    this.notify(ACTION_TYPE.columnUpdate, { sectionId, columnTitle: title });
+    saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
+  }
+
   clear() {
     this.#todoList = [];
     this.notify(this.#todoList);

--- a/store/TodoStore.js
+++ b/store/TodoStore.js
@@ -119,6 +119,15 @@ class TodoStore extends Observable {
     saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
   }
 
+  columnDelete({ sectionId }) {
+    this.#todoList = this.#todoList.filter(
+      (section) => section.id !== sectionId
+    );
+
+    this.notify(ACTION_TYPE.columnDelete, { todoList: this.#todoList });
+    saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
+  }
+
   clear() {
     this.#todoList = [];
     this.notify(this.#todoList);

--- a/store/TodoStore.js
+++ b/store/TodoStore.js
@@ -1,3 +1,4 @@
+import { ACTION_TYPE } from "../constants/action.js";
 import { STORAGE_KEY } from "../constants/storageKey.js";
 import {
   clearLocalStorage,
@@ -22,7 +23,11 @@ class TodoStore extends Observable {
         ? { ...section, items: [...section.items, newTodo] }
         : section
     );
-    this.notify("add", { sectionId, newTodo, todoList: this.#todoList });
+    this.notify(ACTION_TYPE.add, {
+      sectionId,
+      newTodo,
+      todoList: this.#todoList,
+    });
     saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
   }
 
@@ -36,7 +41,35 @@ class TodoStore extends Observable {
         : section
     );
 
-    this.notify("remove", { sectionId, deletedId, todoList: this.#todoList });
+    this.notify(ACTION_TYPE.remove, {
+      sectionId,
+      deletedId,
+      todoList: this.#todoList,
+    });
+    saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
+  }
+
+  update({ sectionId, updatedId, title, content }) {
+    this.#todoList = [...this.#todoList].map((section) =>
+      section.id === sectionId
+        ? {
+            ...section,
+            items: section.items.map((item) =>
+              item.id === updatedId ? { ...item, title, content } : item
+            ),
+          }
+        : section
+    );
+
+    const updatedTodo = this.#todoList
+      .find((section) => section.id === sectionId)
+      .items.find((item) => item.id === updatedId);
+
+    this.notify(ACTION_TYPE.update, {
+      sectionId,
+      updatedTodo,
+      todoList: this.#todoList,
+    });
     saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
   }
 

--- a/store/TodoStore.js
+++ b/store/TodoStore.js
@@ -2,14 +2,14 @@ import { ACTION_TYPE } from "../constants/action.js";
 import { STORAGE_KEY } from "../constants/storageKey.js";
 import {
   clearLocalStorage,
-  loadLocalStorage,
+  initStorage,
   saveLocalStorage,
 } from "../utils/localStorage.js";
-import { getRandomId } from "../utils/random.js";
+import { getRandomId, getRandomString } from "../utils/random.js";
 import Observable from "./Observable.js";
 
 class TodoStore extends Observable {
-  #todoList = loadLocalStorage(STORAGE_KEY.todoList) || [];
+  #todoList = initStorage(STORAGE_KEY.todoList) || [];
 
   add({ sectionId, todo }) {
     const newTodo = {
@@ -104,6 +104,18 @@ class TodoStore extends Observable {
     this.notify(ACTION_TYPE.move, {
       todoList: this.#todoList,
     });
+    saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
+  }
+
+  columnAdd({ title }) {
+    const newColumn = {
+      id: getRandomString(),
+      title,
+      items: [],
+    };
+
+    this.#todoList = [...this.#todoList, newColumn];
+    this.notify(ACTION_TYPE.columnAdd, { newColumn });
     saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
   }
 

--- a/store/TodoStore.js
+++ b/store/TodoStore.js
@@ -73,6 +73,40 @@ class TodoStore extends Observable {
     saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
   }
 
+  move({ prevSectionId, sectionId, itemId }) {
+    const prevColumn = this.#todoList.find(
+      (section) => section.id === prevSectionId
+    );
+
+    const draggedItem = prevColumn.items.find((item) => item.id === itemId);
+
+    // 드래그 요소를 기존 데이터에서 제거
+    const filteredList = this.#todoList.map((section) =>
+      section.id === prevSectionId
+        ? {
+            ...section,
+            items: section.items.filter((item) => item.id !== itemId),
+          }
+        : section
+    );
+
+    // 이동한 섹션에 데이터 추가
+    this.#todoList = filteredList.map((section) => {
+      if (section.id === sectionId && draggedItem) {
+        return {
+          ...section,
+          items: [...section.items, draggedItem],
+        };
+      }
+      return section;
+    });
+
+    this.notify(ACTION_TYPE.move, {
+      todoList: this.#todoList,
+    });
+    saveLocalStorage(STORAGE_KEY.todoList, this.#todoList);
+  }
+
   clear() {
     this.#todoList = [];
     this.notify(this.#todoList);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -16,3 +16,16 @@
   display: flex;
   gap: 3.2rem;
 }
+
+.floating__button {
+  position: fixed;
+  right: 4.8rem;
+  bottom: 4.8rem;
+  width: 5.6rem;
+  height: 5.6rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--color-surface-brand);
+  border-radius: 50%;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -11,10 +11,11 @@
   overflow-y: scroll;
 }
 
-.column__section {
+.column__main {
   height: 90vh;
   display: flex;
   gap: 3.2rem;
+  overflow-x: scroll;
 }
 
 .floating__button {

--- a/utils/random.js
+++ b/utils/random.js
@@ -3,3 +3,14 @@ export const getRandomId = () => {
   crypto.getRandomValues(randomValueArray);
   return randomValueArray[0];
 };
+
+export const getRandomString = (length = 8) => {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  let str = "";
+
+  for (let i = 0; i < length; i++) {
+    str += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+
+  return str;
+};


### PR DESCRIPTION
## 주요 작업

- [x] 칼럼 추가
- [x] 칼럼 수정
- [x] 칼럼 삭제
- [x] 카드 수정 옵저버 패턴 적용
- [x] 카드 이동 옵저버 패턴 적용

## 학습 키워드

### 옵저버 패턴 적용 느낀점

기존에는 UI 업데이트와 데이터 변경이 한 곳에서 이뤄졌다.

따라서, UI 업데이트 따로, 데이터 변경 따로 해주는 듯한 느낌을 받았다.

이 과정에서 오류가 날 경우 UI만 업데이트 되고 데이터는 변경이 안된다거나, 데이터는 변경이 되었는데 UI는 업데이트 안되는 문제가 발생한다.

이를 옵저버 패턴을 적용하여 데이터 바인딩 하였다. store의 변화를 감지하여 데이터의 변경에 따라 UI가 업데이트 되는 방식으로 사고의 흐름을 명확히할 수 있다.

>이벤트가 발생할 때는 store의 데이터를 변화시키고, store에서는 자신을 구독하고 있는 observer들에게 변화를 알려 UI를 업데이트한다.

## 고민과 해결과정

### 문제 파악

- 등록 버튼 또는 저장 버튼을 클릭하면 handleSubmit이 동작하는데,  인자로 넘어온 type 값이 update면 editColumnList를 호출한다.
- editColumnList에서는 인풋창을 텍스트 노드로 대체하고(UI 업데이트), 수정된 값으로 storage에 저장한다.(데이터 처리)
- UI 업데이트와 데이터 처리를 모두 하고 있기 때문에 코드를 파악하기 어려워 옵저버 패턴을 적용하여 관심사를 분리해보자.

### 문제 해결

1. todoStore에 update 메서드를 호출하여 데이터를 변화시킨다.
    - 변환될 데이터를 특정할 수 있는 데이터를 update 메서드의 인자로 넘겨준다.
2. todoStore.update 메서드가 실행될 때 변경되어야 하는 UI 업데이트를 subscribe 콜백함수 내부에 놓는다. (한번만 실행되는 위치에 놓기)


>이벤트가 발생하여 todoStore.update를 호출하면 데이터가 변경되고, 변경된 데이터로 notify를 실행하면 observer들의 콜백 함수를 실행하여 UI를 업데이트 한다.
